### PR TITLE
Closes #165, logging too much data to the database

### DIFF
--- a/src/main/java/nl/haarlem/translations/zdstozgw/converter/impl/emulate/GenereerDocumentIdentificatieEmulator.java
+++ b/src/main/java/nl/haarlem/translations/zdstozgw/converter/impl/emulate/GenereerDocumentIdentificatieEmulator.java
@@ -25,7 +25,7 @@ public class GenereerDocumentIdentificatieEmulator extends Converter {
 
 	@Override
 	public void load() throws ResponseStatusException {
-		this.zdsDocument = (ZdsGenereerDocumentIdentificatieDi02) XmlUtils.getStUFObject(this.getSession().getClientRequestBody(),
+		this.zdsDocument = (ZdsGenereerDocumentIdentificatieDi02) XmlUtils.getStUFObject(this.getSession().getClientOriginalRequestBody(),
 				ZdsGenereerDocumentIdentificatieDi02.class);
 	}
 

--- a/src/main/java/nl/haarlem/translations/zdstozgw/converter/impl/emulate/GenereerZaakIdentificatieEmulator.java
+++ b/src/main/java/nl/haarlem/translations/zdstozgw/converter/impl/emulate/GenereerZaakIdentificatieEmulator.java
@@ -25,8 +25,7 @@ public class GenereerZaakIdentificatieEmulator extends Converter {
 
 	@Override
 	public void load() throws ResponseStatusException {
-		this.zdsDocument = (ZdsGenereerZaakIdentificatieDi02) XmlUtils.getStUFObject(this.getSession().getClientRequestBody(),
-				ZdsGenereerZaakIdentificatieDi02.class);
+		this.zdsDocument = (ZdsGenereerZaakIdentificatieDi02) XmlUtils.getStUFObject(this.getSession().getClientOriginalRequestBody(), ZdsGenereerZaakIdentificatieDi02.class);
 	}
 
 	@Override

--- a/src/main/java/nl/haarlem/translations/zdstozgw/converter/impl/proxy/Proxy.java
+++ b/src/main/java/nl/haarlem/translations/zdstozgw/converter/impl/proxy/Proxy.java
@@ -33,7 +33,7 @@ public class Proxy extends Converter {
 	public ResponseEntity<?> execute() throws ConverterException {
 		var url = this.getTranslation().getLegacyservice();
 		var soapaction = this.getTranslation().getSoapAction();
-		var request = this.getSession().getClientRequestBody();
+		var request = this.getSession().getClientOriginalRequestBody();
 		
 		this.getSession().setFunctie("Proxy");
 		this.getSession().setKenmerk(url);

--- a/src/main/java/nl/haarlem/translations/zdstozgw/converter/impl/replicate/Replicator.java
+++ b/src/main/java/nl/haarlem/translations/zdstozgw/converter/impl/replicate/Replicator.java
@@ -205,7 +205,7 @@ public class Replicator {
     public ResponseEntity<?> proxy() {
 		var url = this.converter.getTranslation().getLegacyservice();
 		var soapaction = this.converter.getTranslation().getSoapAction();
-		var request = this.converter.getSession().getClientRequestBody();
+		var request = this.converter.getSession().getClientOriginalRequestBody();
 		debug.infopoint("proxy", "relaying request to url: " + url + " with soapaction: " + soapaction + " request-size:" + request.length());
 		
 		var legacyresponse = this.zdsClient.post(url, soapaction, request);

--- a/src/main/java/nl/haarlem/translations/zdstozgw/converter/impl/translate/ActualiseerZaakStatusTranslator.java
+++ b/src/main/java/nl/haarlem/translations/zdstozgw/converter/impl/translate/ActualiseerZaakStatusTranslator.java
@@ -21,7 +21,7 @@ public class ActualiseerZaakStatusTranslator extends Converter {
 
 	@Override
 	public void load() throws ResponseStatusException {
-		this.zdsDocument = (ZdsZakLk01ActualiseerZaakstatus) XmlUtils.getStUFObject(this.getSession().getClientRequestBody(),
+		this.zdsDocument = (ZdsZakLk01ActualiseerZaakstatus) XmlUtils.getStUFObject(this.getSession().getClientOriginalRequestBody(),
 				ZdsZakLk01ActualiseerZaakstatus.class);
 	}
 

--- a/src/main/java/nl/haarlem/translations/zdstozgw/converter/impl/translate/CancelCheckoutTranslator.java
+++ b/src/main/java/nl/haarlem/translations/zdstozgw/converter/impl/translate/CancelCheckoutTranslator.java
@@ -24,7 +24,7 @@ public class CancelCheckoutTranslator extends Converter {
 
 	@Override
 	public void load() throws ResponseStatusException {
-		this.zdsDocument = (ZdsCancelCheckoutDi02) XmlUtils.getStUFObject(this.getSession().getClientRequestBody(), ZdsCancelCheckoutDi02.class);
+		this.zdsDocument = (ZdsCancelCheckoutDi02) XmlUtils.getStUFObject(this.getSession().getClientOriginalRequestBody(), ZdsCancelCheckoutDi02.class);
 	}
 
 	@Override

--- a/src/main/java/nl/haarlem/translations/zdstozgw/converter/impl/translate/CreeerZaakTranslator.java
+++ b/src/main/java/nl/haarlem/translations/zdstozgw/converter/impl/translate/CreeerZaakTranslator.java
@@ -21,7 +21,7 @@ public class CreeerZaakTranslator extends Converter {
 
 	@Override
 	public void load() throws ResponseStatusException {
-		this.zdsDocument = (ZdsZakLk01) XmlUtils.getStUFObject(this.getSession().getClientRequestBody(), ZdsZakLk01.class);
+		this.zdsDocument = (ZdsZakLk01) XmlUtils.getStUFObject(this.getSession().getClientOriginalRequestBody(), ZdsZakLk01.class);
 	}
 
 	@Override

--- a/src/main/java/nl/haarlem/translations/zdstozgw/converter/impl/translate/GeefLijstZaakdocumentenTranslator.java
+++ b/src/main/java/nl/haarlem/translations/zdstozgw/converter/impl/translate/GeefLijstZaakdocumentenTranslator.java
@@ -28,7 +28,7 @@ public class GeefLijstZaakdocumentenTranslator extends Converter {
 
 	@Override
 	public void load() throws ResponseStatusException {
-		this.zdsDocument = (ZdsZakLv01) XmlUtils.getStUFObject(this.getSession().getClientRequestBody(), ZdsZakLv01.class);
+		this.zdsDocument = (ZdsZakLv01) XmlUtils.getStUFObject(this.getSession().getClientOriginalRequestBody(), ZdsZakLv01.class);
 	}
 
 	@Override

--- a/src/main/java/nl/haarlem/translations/zdstozgw/converter/impl/translate/GeefZaakDetailsTranslator.java
+++ b/src/main/java/nl/haarlem/translations/zdstozgw/converter/impl/translate/GeefZaakDetailsTranslator.java
@@ -27,7 +27,7 @@ public class GeefZaakDetailsTranslator extends Converter {
 
 	@Override
 	public void load() throws ResponseStatusException {
-		this.zdsDocument = (ZdsZakLv01) XmlUtils.getStUFObject(this.getSession().getClientRequestBody(), ZdsZakLv01.class);
+		this.zdsDocument = (ZdsZakLv01) XmlUtils.getStUFObject(this.getSession().getClientOriginalRequestBody(), ZdsZakLv01.class);
 	}
 
 	@Override

--- a/src/main/java/nl/haarlem/translations/zdstozgw/converter/impl/translate/GeefZaakdocumentBewerkenTranslator.java
+++ b/src/main/java/nl/haarlem/translations/zdstozgw/converter/impl/translate/GeefZaakdocumentBewerkenTranslator.java
@@ -35,7 +35,7 @@ public class GeefZaakdocumentBewerkenTranslator extends Converter {
 
 	@Override
 	public void load() throws ResponseStatusException {
-		this.zdsDocument = (ZdsGeefZaakdocumentbewerkenDi02) XmlUtils.getStUFObject(this.getSession().getClientRequestBody(), ZdsGeefZaakdocumentbewerkenDi02.class);
+		this.zdsDocument = (ZdsGeefZaakdocumentbewerkenDi02) XmlUtils.getStUFObject(this.getSession().getClientOriginalRequestBody(), ZdsGeefZaakdocumentbewerkenDi02.class);
 	}
 
 	@Override

--- a/src/main/java/nl/haarlem/translations/zdstozgw/converter/impl/translate/GeefZaakdocumentLezenTranslator.java
+++ b/src/main/java/nl/haarlem/translations/zdstozgw/converter/impl/translate/GeefZaakdocumentLezenTranslator.java
@@ -27,7 +27,7 @@ public class GeefZaakdocumentLezenTranslator extends Converter {
 
 	@Override
 	public void load() throws ResponseStatusException {
-		this.zdsDocument = (ZdsEdcLv01) XmlUtils.getStUFObject(this.getSession().getClientRequestBody(), ZdsEdcLv01.class);
+		this.zdsDocument = (ZdsEdcLv01) XmlUtils.getStUFObject(this.getSession().getClientOriginalRequestBody(), ZdsEdcLv01.class);
 	}
 
 	@Override

--- a/src/main/java/nl/haarlem/translations/zdstozgw/converter/impl/translate/UpdateZaakTranslator.java
+++ b/src/main/java/nl/haarlem/translations/zdstozgw/converter/impl/translate/UpdateZaakTranslator.java
@@ -20,7 +20,7 @@ public class UpdateZaakTranslator extends Converter {
 
 	@Override
 	public void load() throws ResponseStatusException {
-		this.zdsDocument = (ZdsZakLk01) XmlUtils.getStUFObject(this.getSession().getClientRequestBody(), ZdsZakLk01.class);
+		this.zdsDocument = (ZdsZakLk01) XmlUtils.getStUFObject(this.getSession().getClientOriginalRequestBody(), ZdsZakLk01.class);
 	}
 
 	@Override

--- a/src/main/java/nl/haarlem/translations/zdstozgw/converter/impl/translate/UpdateZaakdocumentTranslator.java
+++ b/src/main/java/nl/haarlem/translations/zdstozgw/converter/impl/translate/UpdateZaakdocumentTranslator.java
@@ -25,7 +25,7 @@ public class UpdateZaakdocumentTranslator extends Converter {
 
 	@Override
 	public void load() throws ResponseStatusException {
-		this.zdsDocument = (ZdsUpdateZaakdocumentDi02) XmlUtils.getStUFObject(this.getSession().getClientRequestBody(), ZdsUpdateZaakdocumentDi02.class);
+		this.zdsDocument = (ZdsUpdateZaakdocumentDi02) XmlUtils.getStUFObject(this.getSession().getClientOriginalRequestBody(), ZdsUpdateZaakdocumentDi02.class);
 	}
 
 	@Override

--- a/src/main/java/nl/haarlem/translations/zdstozgw/converter/impl/translate/VoegZaakdocumentToeTranslator.java
+++ b/src/main/java/nl/haarlem/translations/zdstozgw/converter/impl/translate/VoegZaakdocumentToeTranslator.java
@@ -21,7 +21,7 @@ public class VoegZaakdocumentToeTranslator extends Converter {
 
 	@Override
 	public void load() throws ResponseStatusException {
-		this.zdsDocument = (ZdsEdcLk01) XmlUtils.getStUFObject(this.getSession().getClientRequestBody(), ZdsEdcLk01.class);
+		this.zdsDocument = (ZdsEdcLk01) XmlUtils.getStUFObject(this.getSession().getClientOriginalRequestBody(), ZdsEdcLk01.class);
 	}
 
 	@Override

--- a/src/main/java/nl/haarlem/translations/zdstozgw/requesthandler/RequestHandler.java
+++ b/src/main/java/nl/haarlem/translations/zdstozgw/requesthandler/RequestHandler.java
@@ -69,7 +69,7 @@ public abstract class RequestHandler {
 		}
 		fo03.body.detailsXML = new ZdsDetailsXML();
 		// TODO: put the xml in DetailsXml, without escaping
-		fo03.body.detailsXML.todo = this.converter.getSession().getClientRequestBody();
+		fo03.body.detailsXML.todo = this.converter.getSession().getClientOriginalRequestBody();
 		return fo03;
 	}
 

--- a/src/main/java/nl/haarlem/translations/zdstozgw/requesthandler/impl/logging/RequestResponseCycleService.java
+++ b/src/main/java/nl/haarlem/translations/zdstozgw/requesthandler/impl/logging/RequestResponseCycleService.java
@@ -24,14 +24,14 @@ public class RequestResponseCycleService {
 	}
 
 	public RequestResponseCycle save(RequestResponseCycle requestResponseCycle) {
-		return this.requestResponseCycleRepository.saveAndFlush(requestResponseCycle);
+		return this.requestResponseCycleRepository.save(requestResponseCycle);
 	}
 
 	public ZgwRequestResponseCycle add(ZgwRequestResponseCycle interimRequestResponseCycle) {
-		return this.zgwRequestResponseCycleRepository.saveAndFlush(interimRequestResponseCycle);
+		return this.zgwRequestResponseCycleRepository.save(interimRequestResponseCycle);
 	}
 
 	public ZdsRequestResponseCycle add(ZdsRequestResponseCycle interimRequestResponseCycle) {
-		return this.zdsRequestResponseCycleRepository.saveAndFlush(interimRequestResponseCycle);
+		return this.zdsRequestResponseCycleRepository.save(interimRequestResponseCycle);
 	}	
 }

--- a/src/main/java/nl/haarlem/translations/zdstozgw/requesthandler/impl/logging/ZdsRequestResponseCycle.java
+++ b/src/main/java/nl/haarlem/translations/zdstozgw/requesthandler/impl/logging/ZdsRequestResponseCycle.java
@@ -14,6 +14,7 @@ import javax.persistence.Table;
 import org.springframework.http.ResponseEntity;
 
 import lombok.Data;
+import nl.haarlem.translations.zdstozgw.requesthandler.RequestResponseCycle;
 
 @Data
 @Entity
@@ -30,13 +31,15 @@ public class ZdsRequestResponseCycle {
 	
 	private String zdsUrl;
 	private String zdsSoapAction;
-	@Column(columnDefinition="TEXT")
-	private String zdsRequestBody;
+	
+	@Column(columnDefinition="TEXT", name = "zds_request_body")
+	private String zdsShortenedRequestBody;
 	private Integer zdsRequestSize;
 	
 	private int zdsResponseCode;
-	@Column(columnDefinition="TEXT")
-	private String zdsResponseBody;
+
+	@Column(columnDefinition="TEXT", name = "zds_response_body")
+	private String zdsShortenedResponseBody;
 	private Integer zdsResponseSize;
 	
 	public ZdsRequestResponseCycle() {
@@ -46,12 +49,12 @@ public class ZdsRequestResponseCycle {
 	public ZdsRequestResponseCycle(String zdsUrl, String zdsSoapAction, String zdsRequestBody, String referentienummer) {		
 		this.zdsUrl = zdsUrl;
 		this.zdsSoapAction = zdsSoapAction;
-		this.zdsRequestBody = zdsRequestBody;
 
-		this.referentienummer = referentienummer;
+		this.zdsRequestSize = zdsRequestBody.length();
+		this.zdsShortenedRequestBody = RequestResponseCycle.shortenLongMessages(zdsRequestBody);		
 		
+		this.referentienummer = referentienummer;		
 		startdatetime = LocalDateTime.now();
-		this.zdsRequestSize = this.zdsRequestBody.length();
 	}
 
 	public long getDurationInMilliseconds() {
@@ -60,10 +63,12 @@ public class ZdsRequestResponseCycle {
 	}
 
 	public void setResponse(ResponseEntity<?> response) {
-		this.zdsResponseBody = response.getBody().toString();
-		this.zdsResponseSize = this.zdsResponseBody.length();
 		this.zdsResponseCode = response.getStatusCodeValue();
 
+		var message = response.getBody().toString();
+		this.zdsResponseSize = message.length();
+		this.zdsShortenedResponseBody = RequestResponseCycle.shortenLongMessages(message);	
+				
 		this.stopdatetime = LocalDateTime.now();
 		this.durationInMilliseconds = Duration.between(startdatetime, stopdatetime).toMillis();
 	}

--- a/src/main/java/nl/haarlem/translations/zdstozgw/translation/zds/client/ZDSClient.java
+++ b/src/main/java/nl/haarlem/translations/zdstozgw/translation/zds/client/ZDSClient.java
@@ -65,8 +65,9 @@ public class ZDSClient {
 			String zdsResponseBody = (String) debug.endpoint(debugName, () -> {
 					return method.getResponseBodyAsString();
 			}, (IOException)null);
-			zdsRequestResponseCycle.setZdsResponseCode(responsecode);
-			zdsRequestResponseCycle.setZdsResponseBody(zdsResponseBody);
+			
+			ResponseEntity<?> result = new ResponseEntity<>(zdsResponseBody, HttpStatus.valueOf(responsecode));	
+			zdsRequestResponseCycle.setResponse(result);
 			this.repository.save(zdsRequestResponseCycle);
 
 			if(responsecode != 200) {
@@ -81,7 +82,7 @@ public class ZDSClient {
 			var message = "Soapaction: " + zdsSoapAction + " took " + duration + " milliseconds";
 			log.info(message);
 			debug.infopoint("Duration", message);
-			return new ResponseEntity<>(zdsResponseBody, HttpStatus.valueOf(responsecode));
+			return result;
 		} catch (IOException ce) {
 			throw new ConverterException(
 					"Error: " + ce.toString() + " requesting url:" + zdsUrl + " with soapaction: " + zdsSoapAction, ce);


### PR DESCRIPTION
During replication, we've encountered that a lot of data was being copied.
This pullrequest only copies the start of the request/response-messages to the database