### PR TITLE
Updating zaak to endstatus will ensure resultaat

### DIFF
--- a/src/test/resources/ladybug/Suites4SociaalDomein 14 Translate updateZaak_Lk01.report.xml
+++ b/src/test/resources/ladybug/Suites4SociaalDomein 14 Translate updateZaak_Lk01.report.xml
@@ -1,87 +1,88 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<java version="13.0.2" class="java.beans.XMLDecoder">
+<java version="11.0.11" class="java.beans.XMLDecoder">
  <object class="nl.nn.testtool.Report" id="Report0">
   <void property="checkpoints">
    <void method="add">
     <object class="nl.nn.testtool.Checkpoint">
      <void property="message">
-      <string>&lt;SOAP-ENV:Envelope xsi:schemaLocation=&quot;http://www.egem.nl/StUF/sector/zkn/0310 zkn0310-p28\mutatie\zkn0310_msg_mutatie_resolved.xsd&quot; xmlns:SOAP-ENV=&quot;http://schemas.xmlsoap.org/soap/envelope/&quot; xmlns:BG=&quot;http://www.egem.nl/StUF/sector/bg/0310&quot; xmlns:StUF=&quot;http://www.egem.nl/StUF/StUF0301&quot; xmlns:ZKN=&quot;http://www.egem.nl/StUF/sector/zkn/0310&quot; xmlns:xsi=&quot;http://www.w3.org/2001/XMLSchema-instance&quot;&gt;&#13;
-   &lt;SOAP-ENV:Header/&gt;&#13;
-   &lt;SOAP-ENV:Body&gt;&#13;
-      &lt;ZKN:zakLk01&gt;&#13;
-         &lt;ZKN:stuurgegevens&gt;&#13;
-            &lt;StUF:berichtcode&gt;Lk01&lt;/StUF:berichtcode&gt;&#13;
-            &lt;StUF:zender&gt;&#13;
-               &lt;StUF:organisatie&gt;1900&lt;/StUF:organisatie&gt;&#13;
-               &lt;StUF:applicatie&gt;GWS4all&lt;/StUF:applicatie&gt;&#13;
-               &lt;StUF:gebruiker&gt;Gebruiker&lt;/StUF:gebruiker&gt;&#13;
-            &lt;/StUF:zender&gt;&#13;
-            &lt;StUF:ontvanger&gt;&#13;
-               &lt;StUF:organisatie&gt;1900&lt;/StUF:organisatie&gt;&#13;
-               &lt;StUF:applicatie&gt;CDR&lt;/StUF:applicatie&gt;&#13;
-            &lt;/StUF:ontvanger&gt;&#13;
-            &lt;StUF:referentienummer&gt;ed7c5ec6-8cb6-4e62-a3bd-77973938c18f&lt;/StUF:referentienummer&gt;&#13;
-            &lt;StUF:tijdstipBericht&gt;20210531150153490&lt;/StUF:tijdstipBericht&gt;&#13;
-            &lt;StUF:entiteittype&gt;ZAK&lt;/StUF:entiteittype&gt;&#13;
-         &lt;/ZKN:stuurgegevens&gt;&#13;
-         &lt;ZKN:parameters&gt;&#13;
-            &lt;StUF:mutatiesoort&gt;W&lt;/StUF:mutatiesoort&gt;&#13;
-            &lt;StUF:indicatorOvername&gt;V&lt;/StUF:indicatorOvername&gt;&#13;
-         &lt;/ZKN:parameters&gt;&#13;
-         &lt;ZKN:object StUF:sleutelVerzendend=&quot;1900135&quot; StUF:entiteittype=&quot;ZAK&quot; StUF:verwerkingssoort=&quot;W&quot;&gt;&#13;
-            &lt;ZKN:identificatie&gt;1900135&lt;/ZKN:identificatie&gt;&#13;
-            &lt;ZKN:omschrijving&gt;Aanvraag minimaregelingen (Z)&lt;/ZKN:omschrijving&gt;&#13;
-            &lt;ZKN:startdatum&gt;20210531&lt;/ZKN:startdatum&gt;&#13;
-            &lt;ZKN:registratiedatum&gt;20210531&lt;/ZKN:registratiedatum&gt;&#13;
-            &lt;ZKN:isVan StUF:entiteittype=&quot;ZAKZKT&quot; StUF:verwerkingssoort=&quot;I&quot;&gt;&#13;
-               &lt;ZKN:gerelateerde StUF:entiteittype=&quot;ZKT&quot; StUF:verwerkingssoort=&quot;I&quot;&gt;&#13;
-                  &lt;ZKN:omschrijving&gt;Aanvraag minima&lt;/ZKN:omschrijving&gt;&#13;
-                  &lt;ZKN:code&gt;B1026&lt;/ZKN:code&gt;&#13;
-                  &lt;ZKN:ingangsdatumObject xsi:nil=&quot;true&quot; StUF:noValue=&quot;geenWaarde&quot;/&gt;&#13;
-               &lt;/ZKN:gerelateerde&gt;&#13;
-            &lt;/ZKN:isVan&gt;&#13;
-            &lt;ZKN:leidtTot StUF:entiteittype=&quot;ZAKBSL&quot; StUF:verwerkingssoort=&quot;T&quot; xsi:nil=&quot;true&quot; StUF:noValue=&quot;geenWaarde&quot;/&gt;&#13;
-         &lt;/ZKN:object&gt;&#13;
-         &lt;ZKN:object StUF:sleutelVerzendend=&quot;1900135&quot; StUF:entiteittype=&quot;ZAK&quot; StUF:verwerkingssoort=&quot;W&quot;&gt;&#13;
-            &lt;ZKN:identificatie&gt;1900135&lt;/ZKN:identificatie&gt;&#13;
-            &lt;ZKN:omschrijving&gt;Aanvraag minimaregelingen (Z)&lt;/ZKN:omschrijving&gt;&#13;
-            &lt;ZKN:resultaat&gt;&#13;
-               &lt;!-- &lt;ZKN:omschrijving&gt;Toegekend&lt;/ZKN:omschrijving&gt;&#13; --&gt;
-               &lt;ZKN:omschrijving&gt;Buiten behandeling gesteld&lt;/ZKN:omschrijving&gt;
-            &lt;/ZKN:resultaat&gt;&#13;
-            &lt;ZKN:startdatum&gt;20210531&lt;/ZKN:startdatum&gt;&#13;
-            &lt;ZKN:registratiedatum&gt;20210531&lt;/ZKN:registratiedatum&gt;&#13;
-            &lt;ZKN:einddatum&gt;20210531&lt;/ZKN:einddatum&gt;&#13;
-            &lt;ZKN:isVan StUF:entiteittype=&quot;ZAKZKT&quot; StUF:verwerkingssoort=&quot;I&quot;&gt;&#13;
-               &lt;ZKN:gerelateerde StUF:entiteittype=&quot;ZKT&quot; StUF:verwerkingssoort=&quot;I&quot;&gt;&#13;
-                  &lt;ZKN:omschrijving&gt;Aanvraag minima&lt;/ZKN:omschrijving&gt;&#13;
-                  &lt;ZKN:code&gt;B1026&lt;/ZKN:code&gt;&#13;
-                  &lt;ZKN:ingangsdatumObject xsi:nil=&quot;true&quot; StUF:noValue=&quot;geenWaarde&quot;/&gt;&#13;
-               &lt;/ZKN:gerelateerde&gt;&#13;
-            &lt;/ZKN:isVan&gt;&#13;
-            &lt;ZKN:heeft StUF:entiteittype=&quot;ZAKSTT&quot; StUF:verwerkingssoort=&quot;T&quot;&gt;
-               &lt;ZKN:gerelateerde StUF:entiteittype=&quot;STT&quot; StUF:verwerkingssoort=&quot;T&quot;&gt;
-                  &lt;ZKN:zkt.code&gt;B1026&lt;/ZKN:zkt.code&gt;
-                  &lt;ZKN:zkt.omschrijving&gt;Aanvraag minima&lt;/ZKN:zkt.omschrijving&gt;
-                  &lt;ZKN:volgnummer&gt;0010&lt;/ZKN:volgnummer&gt;
-                  &lt;ZKN:code&gt;Afgehandeld&lt;/ZKN:code&gt;
-                  &lt;ZKN:omschrijving&gt;Afgehandeld&lt;/ZKN:omschrijving&gt;
-                  &lt;ZKN:ingangsdatumObject xsi:nil=&quot;true&quot; StUF:noValue=&quot;geenWaarde&quot;/&gt;
-               &lt;/ZKN:gerelateerde&gt;
-               &lt;ZKN:datumStatusGezet&gt;20210531150153528&lt;/ZKN:datumStatusGezet&gt;
-               &lt;ZKN:isGezetDoor StUF:entiteittype=&quot;ZAKSTTBTR&quot; StUF:verwerkingssoort=&quot;T&quot;&gt;
-                  &lt;ZKN:gerelateerde&gt;
-                     &lt;ZKN:medewerker StUF:entiteittype=&quot;MDW&quot; StUF:verwerkingssoort=&quot;I&quot;&gt;
-                        &lt;ZKN:identificatie&gt;012345678901234567890123&lt;/ZKN:identificatie&gt;
-                        &lt;ZKN:achternaam&gt;G. Bruiker&lt;/ZKN:achternaam&gt;
-                        &lt;ZKN:voorletters xsi:nil=&quot;true&quot; StUF:noValue=&quot;geenWaarde&quot;/&gt;
-                     &lt;/ZKN:medewerker&gt;
-                  &lt;/ZKN:gerelateerde&gt;
-               &lt;/ZKN:isGezetDoor&gt;
-            &lt;/ZKN:heeft&gt;            
-         &lt;/ZKN:object&gt;&#13;
-      &lt;/ZKN:zakLk01&gt;&#13;
-   &lt;/SOAP-ENV:Body&gt;&#13;
+      <string>&lt;SOAP-ENV:Envelope xsi:schemaLocation=&quot;http://www.egem.nl/StUF/sector/zkn/0310 zkn0310-p28\mutatie\zkn0310_msg_mutatie_resolved.xsd&quot; xmlns:SOAP-ENV=&quot;http://schemas.xmlsoap.org/soap/envelope/&quot; xmlns:BG=&quot;http://www.egem.nl/StUF/sector/bg/0310&quot; xmlns:StUF=&quot;http://www.egem.nl/StUF/StUF0301&quot; xmlns:ZKN=&quot;http://www.egem.nl/StUF/sector/zkn/0310&quot; xmlns:xsi=&quot;http://www.w3.org/2001/XMLSchema-instance&quot;&gt;
+&lt;SOAP-ENV:Header/&gt;
+&lt;SOAP-ENV:Body&gt;
+&lt;ZKN:zakLk01&gt;
+&lt;ZKN:stuurgegevens&gt;
+&lt;StUF:berichtcode&gt;Lk01&lt;/StUF:berichtcode&gt;
+&lt;StUF:zender&gt;
+&lt;StUF:organisatie&gt;1900&lt;/StUF:organisatie&gt;
+&lt;StUF:applicatie&gt;GWS4all&lt;/StUF:applicatie&gt;
+&lt;StUF:gebruiker&gt;Gebruiker&lt;/StUF:gebruiker&gt;
+&lt;/StUF:zender&gt;
+&lt;StUF:ontvanger&gt;
+&lt;StUF:organisatie&gt;1900&lt;/StUF:organisatie&gt;
+&lt;StUF:applicatie&gt;CDR&lt;/StUF:applicatie&gt;
+&lt;/StUF:ontvanger&gt;
+&lt;StUF:referentienummer&gt;ed7c5ec6-8cb6-4e62-a3bd-77973938c18f&lt;/StUF:referentienummer&gt;
+&lt;StUF:tijdstipBericht&gt;20210531150153490&lt;/StUF:tijdstipBericht&gt;
+&lt;StUF:entiteittype&gt;ZAK&lt;/StUF:entiteittype&gt;
+&lt;/ZKN:stuurgegevens&gt;
+&lt;ZKN:parameters&gt;
+&lt;StUF:mutatiesoort&gt;W&lt;/StUF:mutatiesoort&gt;
+&lt;StUF:indicatorOvername&gt;V&lt;/StUF:indicatorOvername&gt;
+&lt;/ZKN:parameters&gt;
+&lt;ZKN:object StUF:sleutelVerzendend=&quot;1900322&quot; StUF:entiteittype=&quot;ZAK&quot; StUF:verwerkingssoort=&quot;W&quot;&gt;
+&lt;ZKN:identificatie&gt;1900322&lt;/ZKN:identificatie&gt;
+&lt;ZKN:omschrijving&gt;Aanvraag minimaregelingen (Z)&lt;/ZKN:omschrijving&gt;
+&lt;ZKN:startdatum&gt;20210531&lt;/ZKN:startdatum&gt;
+&lt;ZKN:registratiedatum&gt;20210531&lt;/ZKN:registratiedatum&gt;
+&lt;ZKN:isVan StUF:entiteittype=&quot;ZAKZKT&quot; StUF:verwerkingssoort=&quot;I&quot;&gt;
+&lt;ZKN:gerelateerde StUF:entiteittype=&quot;ZKT&quot; StUF:verwerkingssoort=&quot;I&quot;&gt;
+&lt;ZKN:omschrijving&gt;Aanvraag minima&lt;/ZKN:omschrijving&gt;
+&lt;ZKN:code&gt;B1026&lt;/ZKN:code&gt;
+&lt;ZKN:ingangsdatumObject xsi:nil=&quot;true&quot; StUF:noValue=&quot;geenWaarde&quot;/&gt;
+&lt;/ZKN:gerelateerde&gt;
+&lt;/ZKN:isVan&gt;
+&lt;ZKN:leidtTot StUF:entiteittype=&quot;ZAKBSL&quot; StUF:verwerkingssoort=&quot;T&quot; xsi:nil=&quot;true&quot; StUF:noValue=&quot;geenWaarde&quot;/&gt;
+&lt;/ZKN:object&gt;
+&lt;ZKN:object StUF:sleutelVerzendend=&quot;1900322&quot; StUF:entiteittype=&quot;ZAK&quot; StUF:verwerkingssoort=&quot;W&quot;&gt;
+&lt;ZKN:identificatie&gt;1900322&lt;/ZKN:identificatie&gt;
+&lt;ZKN:omschrijving&gt;Aanvraag minimaregelingen (Z)&lt;/ZKN:omschrijving&gt;
+&lt;ZKN:resultaat&gt;
+&lt;!-- &lt;ZKN:omschrijving&gt;Toegekend&lt;/ZKN:omschrijving&gt;
+--&gt;
+&lt;ZKN:omschrijving&gt;Buiten behandeling gesteld&lt;/ZKN:omschrijving&gt;
+&lt;/ZKN:resultaat&gt;
+&lt;ZKN:startdatum&gt;20210531&lt;/ZKN:startdatum&gt;
+&lt;ZKN:registratiedatum&gt;20210531&lt;/ZKN:registratiedatum&gt;
+&lt;ZKN:einddatum&gt;20210531&lt;/ZKN:einddatum&gt;
+&lt;ZKN:isVan StUF:entiteittype=&quot;ZAKZKT&quot; StUF:verwerkingssoort=&quot;I&quot;&gt;
+&lt;ZKN:gerelateerde StUF:entiteittype=&quot;ZKT&quot; StUF:verwerkingssoort=&quot;I&quot;&gt;
+&lt;ZKN:omschrijving&gt;Aanvraag minima&lt;/ZKN:omschrijving&gt;
+&lt;ZKN:code&gt;B1026&lt;/ZKN:code&gt;
+&lt;ZKN:ingangsdatumObject xsi:nil=&quot;true&quot; StUF:noValue=&quot;geenWaarde&quot;/&gt;
+&lt;/ZKN:gerelateerde&gt;
+&lt;/ZKN:isVan&gt;
+&lt;ZKN:heeft StUF:entiteittype=&quot;ZAKSTT&quot; StUF:verwerkingssoort=&quot;T&quot;&gt;
+&lt;ZKN:gerelateerde StUF:entiteittype=&quot;STT&quot; StUF:verwerkingssoort=&quot;T&quot;&gt;
+&lt;ZKN:zkt.code&gt;B1026&lt;/ZKN:zkt.code&gt;
+&lt;ZKN:zkt.omschrijving&gt;Aanvraag minima&lt;/ZKN:zkt.omschrijving&gt;
+&lt;ZKN:volgnummer&gt;0010&lt;/ZKN:volgnummer&gt;
+&lt;ZKN:code&gt;Afgehandeld&lt;/ZKN:code&gt;
+&lt;ZKN:omschrijving&gt;Afgehandeld&lt;/ZKN:omschrijving&gt;
+&lt;ZKN:ingangsdatumObject xsi:nil=&quot;true&quot; StUF:noValue=&quot;geenWaarde&quot;/&gt;
+&lt;/ZKN:gerelateerde&gt;
+&lt;ZKN:datumStatusGezet&gt;20210531150153528&lt;/ZKN:datumStatusGezet&gt;
+&lt;ZKN:isGezetDoor StUF:entiteittype=&quot;ZAKSTTBTR&quot; StUF:verwerkingssoort=&quot;T&quot;&gt;
+&lt;ZKN:gerelateerde&gt;
+&lt;ZKN:medewerker StUF:entiteittype=&quot;MDW&quot; StUF:verwerkingssoort=&quot;I&quot;&gt;
+&lt;ZKN:identificatie&gt;012345678901234567890123&lt;/ZKN:identificatie&gt;
+&lt;ZKN:achternaam&gt;G. Bruiker&lt;/ZKN:achternaam&gt;
+&lt;ZKN:voorletters xsi:nil=&quot;true&quot; StUF:noValue=&quot;geenWaarde&quot;/&gt;
+&lt;/ZKN:medewerker&gt;
+&lt;/ZKN:gerelateerde&gt;
+&lt;/ZKN:isGezetDoor&gt;
+&lt;/ZKN:heeft&gt;
+&lt;/ZKN:object&gt;
+&lt;/ZKN:zakLk01&gt;
+&lt;/SOAP-ENV:Body&gt;
 &lt;/SOAP-ENV:Envelope&gt;</string>
      </void>
      <void property="name">
@@ -94,7 +95,7 @@
       <string>nl.haarlem.translations.zdstozgw.controller.SoapController</string>
      </void>
      <void property="threadName">
-      <string>Thread-25</string>
+      <string>http-nio-8080-exec-10</string>
      </void>
      <void property="type">
       <int>1</int>
@@ -119,7 +120,7 @@
       <string>nl.haarlem.translations.zdstozgw.controller.SoapController</string>
      </void>
      <void property="threadName">
-      <string>Thread-25</string>
+      <string>http-nio-8080-exec-10</string>
      </void>
      <void property="type">
       <int>4</int>
@@ -144,7 +145,7 @@
       <string>nl.haarlem.translations.zdstozgw.controller.SoapController</string>
      </void>
      <void property="threadName">
-      <string>Thread-25</string>
+      <string>http-nio-8080-exec-10</string>
      </void>
      <void property="type">
       <int>4</int>
@@ -169,7 +170,7 @@
       <string>nl.haarlem.translations.zdstozgw.controller.SoapController</string>
      </void>
      <void property="threadName">
-      <string>Thread-25</string>
+      <string>http-nio-8080-exec-10</string>
      </void>
      <void property="type">
       <int>4</int>
@@ -194,7 +195,7 @@
       <string>nl.haarlem.translations.zdstozgw.controller.SoapController</string>
      </void>
      <void property="threadName">
-      <string>Thread-25</string>
+      <string>http-nio-8080-exec-10</string>
      </void>
      <void property="type">
       <int>4</int>
@@ -219,7 +220,7 @@
       <string>nl.haarlem.translations.zdstozgw.controller.SoapController</string>
      </void>
      <void property="threadName">
-      <string>Thread-25</string>
+      <string>http-nio-8080-exec-10</string>
      </void>
      <void property="type">
       <int>4</int>
@@ -232,7 +233,7 @@
       <int>1</int>
      </void>
      <void property="message">
-      <string>Ladybug_Test_Tool-2.2-20210518.202847--7055860a:17d78389a27:-7fed</string>
+      <string>Ladybug_Test_Tool-2.2-20210518.202847--27fc203d:17e011fd5d0:-7f99</string>
      </void>
      <void property="name">
       <string>referentienummer</string>
@@ -244,7 +245,7 @@
       <string>nl.haarlem.translations.zdstozgw.controller.SoapController</string>
      </void>
      <void property="threadName">
-      <string>Thread-25</string>
+      <string>http-nio-8080-exec-10</string>
      </void>
      <void property="type">
       <int>6</int>
@@ -269,7 +270,7 @@
       <string>nl.haarlem.translations.zdstozgw.controller.SoapController</string>
      </void>
      <void property="threadName">
-      <string>Thread-25</string>
+      <string>http-nio-8080-exec-10</string>
      </void>
      <void property="type">
       <int>6</int>
@@ -294,7 +295,7 @@
       <string>nl.haarlem.translations.zdstozgw.controller.SoapController</string>
      </void>
      <void property="threadName">
-      <string>Thread-25</string>
+      <string>http-nio-8080-exec-10</string>
      </void>
      <void property="type">
       <int>6</int>
@@ -319,7 +320,7 @@
       <string>nl.haarlem.translations.zdstozgw.controller.SoapController</string>
      </void>
      <void property="threadName">
-      <string>Thread-25</string>
+      <string>http-nio-8080-exec-10</string>
      </void>
      <void property="type">
       <int>6</int>
@@ -341,7 +342,7 @@
       <string>nl.haarlem.translations.zdstozgw.translation.zgw.client.ZGWClient</string>
      </void>
      <void property="threadName">
-      <string>Thread-25</string>
+      <string>http-nio-8080-exec-10</string>
      </void>
      <void property="type">
       <int>1</int>
@@ -354,7 +355,7 @@
       <int>2</int>
      </void>
      <void property="message">
-      <string>https://test.openzaak.nl/zaken/api/v1/zaken?identificatie=1900135</string>
+      <string>http://localhost:8000/zaken/api/v1/zaken?identificatie=1900322</string>
      </void>
      <void property="name">
       <string>url</string>
@@ -366,7 +367,7 @@
       <string>nl.haarlem.translations.zdstozgw.translation.zgw.client.ZGWClient</string>
      </void>
      <void property="threadName">
-      <string>Thread-25</string>
+      <string>http-nio-8080-exec-10</string>
      </void>
      <void property="type">
       <int>4</int>
@@ -379,7 +380,7 @@
       <int>2</int>
      </void>
      <void property="message">
-      <string>1900135</string>
+      <string>1900322</string>
      </void>
      <void property="name">
       <string>Parameter identificatie</string>
@@ -391,7 +392,7 @@
       <string>nl.haarlem.translations.zdstozgw.translation.zgw.client.ZGWClient</string>
      </void>
      <void property="threadName">
-      <string>Thread-25</string>
+      <string>http-nio-8080-exec-10</string>
      </void>
      <void property="type">
       <int>4</int>
@@ -404,7 +405,7 @@
       <int>2</int>
      </void>
      <void property="message">
-      <string>{&quot;count&quot;:1,&quot;next&quot;:null,&quot;previous&quot;:null,&quot;results&quot;:[{&quot;url&quot;:&quot;https://fieldlab.westeurope.cloudapp.azure.com/zaken/api/v1/zaken/129d2dc5-2d3a-4cdf-9b09-1c5c0041c946&quot;,&quot;uuid&quot;:&quot;129d2dc5-2d3a-4cdf-9b09-1c5c0041c946&quot;,&quot;identificatie&quot;:&quot;1900135&quot;,&quot;bronorganisatie&quot;:&quot;823288444&quot;,&quot;omschrijving&quot;:&quot;Aanvraag minimaregelingen (Z)&quot;,&quot;toelichting&quot;:&quot;&quot;,&quot;zaaktype&quot;:&quot;https://fieldlab.westeurope.cloudapp.azure.com/catalogi/api/v1/zaaktypen/d06a9962-a04e-4d64-9c5d-78dbde1a6b8e&quot;,&quot;registratiedatum&quot;:&quot;2021-05-31&quot;,&quot;verantwoordelijkeOrganisatie&quot;:&quot;823288444&quot;,&quot;startdatum&quot;:&quot;2021-05-31&quot;,&quot;einddatum&quot;:null,&quot;einddatumGepland&quot;:&quot;2021-01-01&quot;,&quot;uiterlijkeEinddatumAfdoening&quot;:null,&quot;publicatiedatum&quot;:null,&quot;communicatiekanaal&quot;:&quot;&quot;,&quot;productenOfDiensten&quot;:[],&quot;vertrouwelijkheidaanduiding&quot;:&quot;vertrouwelijk&quot;,&quot;betalingsindicatie&quot;:&quot;&quot;,&quot;betalingsindicatieWeergave&quot;:&quot;&quot;,&quot;laatsteBetaaldatum&quot;:null,&quot;zaakgeometrie&quot;:null,&quot;verlenging&quot;:{&quot;reden&quot;:&quot;&quot;,&quot;duur&quot;:null},&quot;opschorting&quot;:{&quot;indicatie&quot;:true,&quot;reden&quot;:&quot;niet tijdig verstrekken inform&quot;},&quot;selectielijstklasse&quot;:&quot;&quot;,&quot;hoofdzaak&quot;:null,&quot;deelzaken&quot;:[],&quot;relevanteAndereZaken&quot;:[],&quot;eigenschappen&quot;:[],&quot;status&quot;:&quot;https://fieldlab.westeurope.cloudapp.azure.com/zaken/api/v1/statussen/36021762-52e2-43c4-86e8-a95e92bc6c88&quot;,&quot;kenmerken&quot;:[{&quot;kenmerk&quot;:&quot;273846&quot;,&quot;bron&quot;:&quot;GWS4all&quot;}],&quot;archiefnominatie&quot;:&quot;vernietigen&quot;,&quot;archiefstatus&quot;:&quot;nog_te_archiveren&quot;,&quot;archiefactiedatum&quot;:null,&quot;resultaat&quot;:null}]}</string>
+      <string>{&quot;count&quot;:1,&quot;next&quot;:null,&quot;previous&quot;:null,&quot;results&quot;:[{&quot;url&quot;:&quot;http://localhost:8000/zaken/api/v1/zaken/a1e2e3b5-b1c7-479c-9238-c1b1132c26ec&quot;,&quot;uuid&quot;:&quot;a1e2e3b5-b1c7-479c-9238-c1b1132c26ec&quot;,&quot;identificatie&quot;:&quot;1900322&quot;,&quot;bronorganisatie&quot;:&quot;823288444&quot;,&quot;omschrijving&quot;:&quot;Aanvraag minimaregelingen (Z)&quot;,&quot;toelichting&quot;:&quot;&quot;,&quot;zaaktype&quot;:&quot;http://localhost:8000/catalogi/api/v1/zaaktypen/0794b397-f7fb-49d8-8657-8c9a75405757&quot;,&quot;registratiedatum&quot;:&quot;2021-12-28&quot;,&quot;verantwoordelijkeOrganisatie&quot;:&quot;823288444&quot;,&quot;startdatum&quot;:&quot;2021-12-28&quot;,&quot;einddatum&quot;:null,&quot;einddatumGepland&quot;:&quot;2021-01-01&quot;,&quot;uiterlijkeEinddatumAfdoening&quot;:null,&quot;publicatiedatum&quot;:null,&quot;communicatiekanaal&quot;:&quot;&quot;,&quot;productenOfDiensten&quot;:[],&quot;vertrouwelijkheidaanduiding&quot;:&quot;vertrouwelijk&quot;,&quot;betalingsindicatie&quot;:&quot;&quot;,&quot;betalingsindicatieWeergave&quot;:&quot;&quot;,&quot;laatsteBetaaldatum&quot;:null,&quot;zaakgeometrie&quot;:null,&quot;verlenging&quot;:{&quot;reden&quot;:&quot;Overig&quot;,&quot;duur&quot;:&quot;P99D&quot;},&quot;opschorting&quot;:{&quot;indicatie&quot;:false,&quot;reden&quot;:&quot;&quot;},&quot;selectielijstklasse&quot;:&quot;&quot;,&quot;hoofdzaak&quot;:null,&quot;deelzaken&quot;:[],&quot;relevanteAndereZaken&quot;:[],&quot;eigenschappen&quot;:[],&quot;status&quot;:&quot;http://localhost:8000/zaken/api/v1/statussen/9c2c450b-5560-4d74-bc54-664c1769a53d&quot;,&quot;kenmerken&quot;:[{&quot;kenmerk&quot;:&quot;273846&quot;,&quot;bron&quot;:&quot;GWS4all&quot;}],&quot;archiefnominatie&quot;:&quot;vernietigen&quot;,&quot;archiefstatus&quot;:&quot;nog_te_archiveren&quot;,&quot;archiefactiedatum&quot;:null,&quot;resultaat&quot;:null}]}</string>
      </void>
      <void property="name">
       <string>ZGWClient GET</string>
@@ -419,7 +420,7 @@
       <boolean>true</boolean>
      </void>
      <void property="threadName">
-      <string>Thread-25</string>
+      <string>http-nio-8080-exec-10</string>
      </void>
      <void property="type">
       <int>2</int>
@@ -432,7 +433,7 @@
       <int>1</int>
      </void>
      <void property="message">
-      <string>GET to: https://test.openzaak.nl/zaken/api/v1/zaken?identificatie=1900135 took 0 milliseconds</string>
+      <string>GET to: http://localhost:8000/zaken/api/v1/zaken?identificatie=1900322 took 0 milliseconds</string>
      </void>
      <void property="name">
       <string>Duration</string>
@@ -444,7 +445,7 @@
       <string>nl.haarlem.translations.zdstozgw.translation.zgw.client.ZGWClient</string>
      </void>
      <void property="threadName">
-      <string>Thread-25</string>
+      <string>http-nio-8080-exec-10</string>
      </void>
      <void property="type">
       <int>6</int>
@@ -466,7 +467,7 @@
       <string>nl.haarlem.translations.zdstozgw.translation.zgw.client.ZGWClient</string>
      </void>
      <void property="threadName">
-      <string>Thread-25</string>
+      <string>http-nio-8080-exec-10</string>
      </void>
      <void property="type">
       <int>1</int>
@@ -479,7 +480,7 @@
       <int>2</int>
      </void>
      <void property="message">
-      <string>https://fieldlab.westeurope.cloudapp.azure.com/catalogi/api/v1/zaaktypen/d06a9962-a04e-4d64-9c5d-78dbde1a6b8e</string>
+      <string>http://localhost:8000/catalogi/api/v1/zaaktypen/0794b397-f7fb-49d8-8657-8c9a75405757</string>
      </void>
      <void property="name">
       <string>url</string>
@@ -491,7 +492,7 @@
       <string>nl.haarlem.translations.zdstozgw.translation.zgw.client.ZGWClient</string>
      </void>
      <void property="threadName">
-      <string>Thread-25</string>
+      <string>http-nio-8080-exec-10</string>
      </void>
      <void property="type">
       <int>4</int>
@@ -504,7 +505,7 @@
       <int>2</int>
      </void>
      <void property="message">
-      <string>{&quot;url&quot;:&quot;https://fieldlab.westeurope.cloudapp.azure.com/catalogi/api/v1/zaaktypen/d06a9962-a04e-4d64-9c5d-78dbde1a6b8e&quot;,&quot;identificatie&quot;:&quot;B1026&quot;,&quot;omschrijving&quot;:&quot;Minimaregeling aanvraag&quot;,&quot;omschrijvingGeneriek&quot;:&quot;&quot;,&quot;vertrouwelijkheidaanduiding&quot;:&quot;vertrouwelijk&quot;,&quot;doel&quot;:&quot;Dit werkproces betreft het beoordelen van een aanvraag voor een minimaregeling. Een minimaregeling is een inkomensondersteunende voorziening voor mensen met een inkomen dat niet hoger is dan 110% van het sociaal minimum. De gemeente kan deze (gedeeltelijke) vergoeding toekennen voor kosten van witgoedapparatuur, kosten voor kinderen en kosten in verband met ouderdom, een handicap of chronische ziekte. Zie voor de minimaregeling voor de kosten in verband met een ziektekostenverzekering werkproces B1261 \&quot;Collectieve aanvullende zorgverzekering\&quot;.&quot;,&quot;aanleiding&quot;:&quot;Aanvraag&quot;,&quot;toelichting&quot;:&quot;&quot;,&quot;indicatieInternOfExtern&quot;:&quot;intern&quot;,&quot;handelingInitiator&quot;:&quot;aanvragen&quot;,&quot;onderwerp&quot;:&quot;onderwerp&quot;,&quot;handelingBehandelaar&quot;:&quot;handelingBehandelaar&quot;,&quot;doorlooptijd&quot;:&quot;P30D&quot;,&quot;servicenorm&quot;:null,&quot;opschortingEnAanhoudingMogelijk&quot;:true,&quot;verlengingMogelijk&quot;:false,&quot;verlengingstermijn&quot;:null,&quot;trefwoorden&quot;:[],&quot;publicatieIndicatie&quot;:true,&quot;publicatietekst&quot;:&quot;&quot;,&quot;verantwoordingsrelatie&quot;:[],&quot;productenOfDiensten&quot;:[&quot;http://nergens.org/&quot;],&quot;selectielijstProcestype&quot;:&quot;https://selectielijst.openzaak.nl/api/v1/procestypen/aa8aa2fd-b9c6-4e34-9a6c-58a677f60ea0&quot;,&quot;referentieproces&quot;:{&quot;naam&quot;:&quot;Verzoeken behandelen&quot;,&quot;link&quot;:&quot;https://referentielijsten-api.vng.cloud/api/v1/procestypen/3030daa1-d516-4cd9-8276-ef0977e32b20&quot;},&quot;catalogus&quot;:&quot;https://fieldlab.westeurope.cloudapp.azure.com/catalogi/api/v1/catalogussen/782ae7eb-503f-4235-aac0-015d28381934&quot;,&quot;statustypen&quot;:[&quot;https://fieldlab.westeurope.cloudapp.azure.com/catalogi/api/v1/statustypen/6cd40dd5-0e5d-473e-b656-69d3073c6987&quot;,&quot;https://fieldlab.westeurope.cloudapp.azure.com/catalogi/api/v1/statustypen/31667f4f-6469-4706-909c-cc0a7dccda2c&quot;,&quot;https://fieldlab.westeurope.cloudapp.azure.com/catalogi/api/v1/statustypen/73aee1e9-59d3-4cdf-a745-ad4cd9609f0e&quot;,&quot;https://fieldlab.westeurope.cloudapp.azure.com/catalogi/api/v1/statustypen/bc4bb3f8-f819-4939-b5d2-40c99d8d4aa6&quot;,&quot;https://fieldlab.westeurope.cloudapp.azure.com/catalogi/api/v1/statustypen/18bcaedc-80d5-4754-a29e-78f2a75069c9&quot;,&quot;https://fieldlab.westeurope.cloudapp.azure.com/catalogi/api/v1/statustypen/950542a9-957b-40f6-9729-6ee873f83425&quot;,&quot;https://fieldlab.westeurope.cloudapp.azure.com/catalogi/api/v1/statustypen/9e32f110-e61c-4668-8eed-8bc7792e73ca&quot;,&quot;https://fieldlab.westeurope.cloudapp.azure.com/catalogi/api/v1/statustypen/c5768a87-7725-4c76-8657-24305efb916d&quot;],&quot;resultaattypen&quot;:[&quot;https://fieldlab.westeurope.cloudapp.azure.com/catalogi/api/v1/resultaattypen/26e4726d-3b82-4c2d-b6f1-85fe811c63a2&quot;,&quot;https://fieldlab.westeurope.cloudapp.azure.com/catalogi/api/v1/resultaattypen/5236ff3b-aad5-47de-81b9-fe5b46cc22e2&quot;,&quot;https://fieldlab.westeurope.cloudapp.azure.com/catalogi/api/v1/resultaattypen/cd6726a2-0fdd-4b6d-ba1c-8cc5dee185ac&quot;,&quot;https://fieldlab.westeurope.cloudapp.azure.com/catalogi/api/v1/resultaattypen/a82392e8-91a1-4d5c-94be-f3c3b05ee5d5&quot;],&quot;eigenschappen&quot;:[],&quot;informatieobjecttypen&quot;:[&quot;https://fieldlab.westeurope.cloudapp.azure.com/catalogi/api/v1/informatieobjecttypen/84a3aca4-58ca-465a-9f66-dfb5bbb84ccc&quot;,&quot;https://fieldlab.westeurope.cloudapp.azure.com/catalogi/api/v1/informatieobjecttypen/065dc0d7-1afa-4e80-b9bf-281680fda6fd&quot;,&quot;https://fieldlab.westeurope.cloudapp.azure.com/catalogi/api/v1/informatieobjecttypen/a7eceae7-2eda-4564-a721-785494a9929a&quot;,&quot;https://fieldlab.westeurope.cloudapp.azure.com/catalogi/api/v1/informatieobjecttypen/ad5714b7-caf6-45f5-841f-7bca9ee0d586&quot;,&quot;https://fieldlab.westeurope.cloudapp.azure.com/catalogi/api/v1/informatieobjecttypen/280adf17-d5ab-4525-b2f9-b10b33c8a7d7&quot;,&quot;https://fieldlab.westeurope.cloudapp.azure.com/catalogi/api/v1/informatieobjecttypen/5ffd0e49-ddb7-4289-9365-a1de4b998b2a&quot;,&quot;https://fieldlab.westeurope.cloudapp.azure.com/catalogi/api/v1/informatieobjecttypen/6a35f1cb-c6ea-4f03-b126-4e7138431c68&quot;,&quot;https://fieldlab.westeurope.cloudapp.azure.com/catalogi/api/v1/informatieobjecttypen/e208d29e-8a19-4e40-b8a9-78a57b334c80&quot;,&quot;https://fieldlab.westeurope.cloudapp.azure.com/catalogi/api/v1/informatieobjecttypen/4208ac80-7587-4a42-8fc7-6ca25e5493e0&quot;,&quot;https://fieldlab.westeurope.cloudapp.azure.com/catalogi/api/v1/informatieobjecttypen/532c7e0c-e3a9-496b-b713-2001ac17dae1&quot;,&quot;https://fieldlab.westeurope.cloudapp.azure.com/catalogi/api/v1/informatieobjecttypen/d7da83c3-9847-495e-ac00-5df71e49f547&quot;,&quot;https://fieldlab.westeurope.cloudapp.azure.com/catalogi/api/v1/informatieobjecttypen/7ae962cd-3328-49b2-a31d-16512aaed379&quot;,&quot;https://fieldlab.westeurope.cloudapp.azure.com/catalogi/api/v1/informatieobjecttypen/2460a8d9-966c-4dd5-b141-4ea1717b65db&quot;,&quot;https://fieldlab.westeurope.cloudapp.azure.com/catalogi/api/v1/informatieobjecttypen/63ec67b5-4ea3-4034-8b61-a3e67499736d&quot;,&quot;https://fieldlab.westeurope.cloudapp.azure.com/catalogi/api/v1/informatieobjecttypen/05f2200b-b0c9-4151-88b0-363707f4d453&quot;,&quot;https://fieldlab.westeurope.cloudapp.azure.com/catalogi/api/v1/informatieobjecttypen/88d5d73f-5a29-4f89-9d82-ee8fc627b991&quot;,&quot;https://fieldlab.westeurope.cloudapp.azure.com/catalogi/api/v1/informatieobjecttypen/a1871ae1-d159-4670-b693-d325da44b3d4&quot;],&quot;roltypen&quot;:[&quot;https://fieldlab.westeurope.cloudapp.azure.com/catalogi/api/v1/roltypen/366fd9d5-49d8-4b5d-81a9-168d11f4311d&quot;,&quot;https://fieldlab.westeurope.cloudapp.azure.com/catalogi/api/v1/roltypen/2e1ad749-8e54-4d52-98fb-45a61ae6ea4f&quot;,&quot;https://fieldlab.westeurope.cloudapp.azure.com/catalogi/api/v1/roltypen/fe63b896-3e17-4256-9f85-7d7ce79c828e&quot;,&quot;https://fieldlab.westeurope.cloudapp.azure.com/catalogi/api/v1/roltypen/93f0618b-bf59-4bdf-91c8-bd2100dd4ae2&quot;,&quot;https://fieldlab.westeurope.cloudapp.azure.com/catalogi/api/v1/roltypen/3adb7e2f-a121-4936-8c38-248d281cc618&quot;,&quot;https://fieldlab.westeurope.cloudapp.azure.com/catalogi/api/v1/roltypen/42cb7c3e-50cd-4a8c-80aa-cacbd0a89a84&quot;],&quot;besluittypen&quot;:[],&quot;deelzaaktypen&quot;:[],&quot;gerelateerdeZaaktypen&quot;:[],&quot;beginGeldigheid&quot;:&quot;2021-03-04&quot;,&quot;eindeGeldigheid&quot;:null,&quot;versiedatum&quot;:&quot;2021-03-04&quot;,&quot;concept&quot;:false}</string>
+      <string>{&quot;url&quot;:&quot;http://localhost:8000/catalogi/api/v1/zaaktypen/0794b397-f7fb-49d8-8657-8c9a75405757&quot;,&quot;identificatie&quot;:&quot;B1026&quot;,&quot;omschrijving&quot;:&quot;Minimaregeling aanvraag&quot;,&quot;omschrijvingGeneriek&quot;:&quot;&quot;,&quot;vertrouwelijkheidaanduiding&quot;:&quot;vertrouwelijk&quot;,&quot;doel&quot;:&quot;Dit werkproces betreft het beoordelen van een aanvraag voor een minimaregeling. Een minimaregeling is een inkomensondersteunende voorziening voor mensen met een inkomen dat niet hoger is dan 110% van het sociaal minimum. De gemeente kan deze (gedeeltelijke) vergoeding toekennen voor kosten van witgoedapparatuur, kosten voor kinderen en kosten in verband met ouderdom, een handicap of chronische ziekte. Zie voor de minimaregeling voor de kosten in verband met een ziektekostenverzekering werkproces B1261 \&quot;Collectieve aanvullende zorgverzekering\&quot;. Een omschrijving van hetgeen beoogd is te bereiken met een zaak van dit zaaktype.&quot;,&quot;aanleiding&quot;:&quot;Aanvraag&quot;,&quot;toelichting&quot;:&quot;&quot;,&quot;indicatieInternOfExtern&quot;:&quot;intern&quot;,&quot;handelingInitiator&quot;:&quot;aanvragen&quot;,&quot;onderwerp&quot;:&quot;onderwerp&quot;,&quot;handelingBehandelaar&quot;:&quot;handelingBehandelaar&quot;,&quot;doorlooptijd&quot;:&quot;P30D&quot;,&quot;servicenorm&quot;:null,&quot;opschortingEnAanhoudingMogelijk&quot;:true,&quot;verlengingMogelijk&quot;:false,&quot;verlengingstermijn&quot;:null,&quot;trefwoorden&quot;:[],&quot;publicatieIndicatie&quot;:true,&quot;publicatietekst&quot;:&quot;&quot;,&quot;verantwoordingsrelatie&quot;:[],&quot;productenOfDiensten&quot;:[&quot;https://test.openzaak.nl/admin/catalogi/zaaktype/add/?_changelist_filters=catalogus__id__exact%3D21&amp;catalogus=21&quot;],&quot;selectielijstProcestype&quot;:&quot;https://selectielijst.openzaak.nl/api/v1/procestypen/aa8aa2fd-b9c6-4e34-9a6c-58a677f60ea0&quot;,&quot;referentieproces&quot;:{&quot;naam&quot;:&quot;Verzoeken behandelen&quot;,&quot;link&quot;:&quot;https://referentielijsten-api.vng.cloud/api/v1/procestypen/3030daa1-d516-4cd9-8276-ef0977e32b20&quot;},&quot;catalogus&quot;:&quot;http://localhost:8000/catalogi/api/v1/catalogussen/3ab23698-ba64-4bd8-9755-848adb68ad09&quot;,&quot;statustypen&quot;:[&quot;http://localhost:8000/catalogi/api/v1/statustypen/6cbd5d70-9da8-4481-8503-014578f0a34e&quot;,&quot;http://localhost:8000/catalogi/api/v1/statustypen/d5bf25ba-00c3-4ae5-b273-0b2826474ef2&quot;,&quot;http://localhost:8000/catalogi/api/v1/statustypen/4c5ab517-d89c-4048-983b-ad4333edeee2&quot;,&quot;http://localhost:8000/catalogi/api/v1/statustypen/a0aa3459-5305-499a-a1dd-c090ea44da38&quot;,&quot;http://localhost:8000/catalogi/api/v1/statustypen/20372f07-f89d-4517-9a0c-8ebf001a0b1d&quot;,&quot;http://localhost:8000/catalogi/api/v1/statustypen/98b30f4c-98c3-4a24-a04a-51f909aeb972&quot;,&quot;http://localhost:8000/catalogi/api/v1/statustypen/5cce8bb5-1c75-4847-807a-5359dd3e8a71&quot;],&quot;resultaattypen&quot;:[&quot;http://localhost:8000/catalogi/api/v1/resultaattypen/314ba199-e363-4676-8b38-e9daebf31ddd&quot;,&quot;http://localhost:8000/catalogi/api/v1/resultaattypen/7db13851-91be-45ee-a3ca-bc94276ae37d&quot;],&quot;eigenschappen&quot;:[],&quot;informatieobjecttypen&quot;:[&quot;http://localhost:8000/catalogi/api/v1/informatieobjecttypen/7bb785d8-d3bb-40f5-b9b8-8b080f0d3967&quot;],&quot;roltypen&quot;:[&quot;http://localhost:8000/catalogi/api/v1/roltypen/2cea9867-69be-4bd8-ae21-4e63c0aa4c45&quot;,&quot;http://localhost:8000/catalogi/api/v1/roltypen/2c8c4a80-86b4-4aeb-b8d9-abcc57b47d45&quot;,&quot;http://localhost:8000/catalogi/api/v1/roltypen/6c540a07-ec55-4507-ad8f-bff612e862c5&quot;,&quot;http://localhost:8000/catalogi/api/v1/roltypen/23623331-53cc-4b50-8582-66671e044125&quot;,&quot;http://localhost:8000/catalogi/api/v1/roltypen/e50c7156-a3ba-4b94-88c1-de49a5cfdef7&quot;],&quot;besluittypen&quot;:[],&quot;deelzaaktypen&quot;:[],&quot;gerelateerdeZaaktypen&quot;:[],&quot;beginGeldigheid&quot;:&quot;2021-03-29&quot;,&quot;eindeGeldigheid&quot;:null,&quot;versiedatum&quot;:&quot;2021-03-29&quot;,&quot;concept&quot;:false}</string>
      </void>
      <void property="name">
       <string>ZGWClient GET</string>
@@ -519,7 +520,7 @@
       <boolean>true</boolean>
      </void>
      <void property="threadName">
-      <string>Thread-25</string>
+      <string>http-nio-8080-exec-10</string>
      </void>
      <void property="type">
       <int>2</int>
@@ -532,7 +533,7 @@
       <int>1</int>
      </void>
      <void property="message">
-      <string>GET to: https://fieldlab.westeurope.cloudapp.azure.com/catalogi/api/v1/zaaktypen/d06a9962-a04e-4d64-9c5d-78dbde1a6b8e took 0 milliseconds</string>
+      <string>GET to: http://localhost:8000/catalogi/api/v1/zaaktypen/0794b397-f7fb-49d8-8657-8c9a75405757 took 0 milliseconds</string>
      </void>
      <void property="name">
       <string>Duration</string>
@@ -544,7 +545,7 @@
       <string>nl.haarlem.translations.zdstozgw.translation.zgw.client.ZGWClient</string>
      </void>
      <void property="threadName">
-      <string>Thread-25</string>
+      <string>http-nio-8080-exec-10</string>
      </void>
      <void property="type">
       <int>6</int>
@@ -561,25 +562,25 @@
   &quot;betalingsindicatieWeergave&quot;: &quot;&quot;,
   &quot;deelzaken&quot;: [],
   &quot;eigenschappen&quot;: [],
-  &quot;status&quot;: &quot;https://fieldlab.westeurope.cloudapp.azure.com/zaken/api/v1/statussen/36021762-52e2-43c4-86e8-a95e92bc6c88&quot;,
-  &quot;url&quot;: &quot;https://fieldlab.westeurope.cloudapp.azure.com/zaken/api/v1/zaken/129d2dc5-2d3a-4cdf-9b09-1c5c0041c946&quot;,
-  &quot;uuid&quot;: &quot;129d2dc5-2d3a-4cdf-9b09-1c5c0041c946&quot;,
-  &quot;identificatie&quot;: &quot;1900135&quot;,
+  &quot;status&quot;: &quot;http://localhost:8000/zaken/api/v1/statussen/9c2c450b-5560-4d74-bc54-664c1769a53d&quot;,
+  &quot;url&quot;: &quot;http://localhost:8000/zaken/api/v1/zaken/a1e2e3b5-b1c7-479c-9238-c1b1132c26ec&quot;,
+  &quot;uuid&quot;: &quot;a1e2e3b5-b1c7-479c-9238-c1b1132c26ec&quot;,
+  &quot;identificatie&quot;: &quot;1900322&quot;,
   &quot;bronorganisatie&quot;: &quot;823288444&quot;,
   &quot;omschrijving&quot;: &quot;Aanvraag minimaregelingen (Z)&quot;,
   &quot;toelichting&quot;: &quot;&quot;,
-  &quot;zaaktype&quot;: &quot;https://fieldlab.westeurope.cloudapp.azure.com/catalogi/api/v1/zaaktypen/d06a9962-a04e-4d64-9c5d-78dbde1a6b8e&quot;,
-  &quot;registratiedatum&quot;: &quot;2021-05-31&quot;,
+  &quot;zaaktype&quot;: &quot;http://localhost:8000/catalogi/api/v1/zaaktypen/0794b397-f7fb-49d8-8657-8c9a75405757&quot;,
+  &quot;registratiedatum&quot;: &quot;2021-12-28&quot;,
   &quot;verantwoordelijkeOrganisatie&quot;: &quot;823288444&quot;,
-  &quot;startdatum&quot;: &quot;2021-05-31&quot;,
+  &quot;startdatum&quot;: &quot;2021-12-28&quot;,
   &quot;einddatumGepland&quot;: &quot;2021-01-01&quot;,
   &quot;communicatiekanaal&quot;: &quot;&quot;,
   &quot;productenOfDiensten&quot;: [],
   &quot;vertrouwelijkheidaanduiding&quot;: &quot;vertrouwelijk&quot;,
   &quot;betalingsindicatie&quot;: &quot;&quot;,
-  &quot;opschorting&quot;: {
-    &quot;indicatie&quot;: true,
-    &quot;reden&quot;: &quot;niet tijdig verstrekken inform&quot;
+  &quot;verlenging&quot;: {
+    &quot;reden&quot;: &quot;Overig&quot;,
+    &quot;duur&quot;: &quot;P99D&quot;
   },
   &quot;selectielijstklasse&quot;: &quot;&quot;,
   &quot;relevanteAndereZaken&quot;: [],
@@ -603,7 +604,7 @@
       <string>nl.haarlem.translations.zdstozgw.debug.ModelMapperAdvice</string>
      </void>
      <void property="threadName">
-      <string>Thread-25</string>
+      <string>http-nio-8080-exec-10</string>
      </void>
      <void property="type">
       <int>1</int>
@@ -625,16 +626,16 @@
       &quot;bron&quot;: &quot;GWS4all&quot;
     }
   ],
-  &quot;startdatum&quot;: &quot;20210531&quot;,
-  &quot;registratiedatum&quot;: &quot;20210531&quot;,
+  &quot;startdatum&quot;: &quot;20211228&quot;,
+  &quot;registratiedatum&quot;: &quot;20211228&quot;,
   &quot;einddatumGepland&quot;: &quot;20210101&quot;,
-  &quot;opschorting&quot;: {
-    &quot;indicatie&quot;: &quot;J&quot;,
-    &quot;reden&quot;: &quot;niet tijdig verstrekken inform&quot;
+  &quot;verlenging&quot;: {
+    &quot;duur&quot;: &quot;P99D&quot;,
+    &quot;reden&quot;: &quot;Overig&quot;
   },
   &quot;archiefnominatie&quot;: &quot;N&quot;,
   &quot;entiteittype&quot;: &quot;ZAK&quot;,
-  &quot;identificatie&quot;: &quot;1900135&quot;
+  &quot;identificatie&quot;: &quot;1900322&quot;
 }</string>
      </void>
      <void property="name">
@@ -647,35 +648,10 @@
       <string>nl.haarlem.translations.zdstozgw.debug.ModelMapperAdvice</string>
      </void>
      <void property="threadName">
-      <string>Thread-25</string>
+      <string>http-nio-8080-exec-10</string>
      </void>
      <void property="type">
       <int>2</int>
-     </void>
-    </object>
-   </void>
-   <void method="add">
-    <object class="nl.nn.testtool.Checkpoint">
-     <void property="level">
-      <int>1</int>
-     </void>
-     <void property="message">
-      <string>The field: opschorting does not match (DELETED) stored-value:&apos;ZdsOpschorting(indicatie=J, reden=niet tijdig verstrekken inform)&apos; , was-value:&apos;null&apos;</string>
-     </void>
-     <void property="name">
-      <string>Warning</string>
-     </void>
-     <void property="report">
-      <object idref="Report0"/>
-     </void>
-     <void property="sourceClassName">
-      <string>nl.haarlem.translations.zdstozgw.translation.zds.services.ZaakService</string>
-     </void>
-     <void property="threadName">
-      <string>Thread-25</string>
-     </void>
-     <void property="type">
-      <int>6</int>
      </void>
     </object>
    </void>
@@ -697,7 +673,7 @@
       <string>nl.haarlem.translations.zdstozgw.translation.zds.services.ZaakService</string>
      </void>
      <void property="threadName">
-      <string>Thread-25</string>
+      <string>http-nio-8080-exec-10</string>
      </void>
      <void property="type">
       <int>6</int>
@@ -710,7 +686,7 @@
       <int>1</int>
      </void>
      <void property="message">
-      <string>The field: kenmerk does not match (DELETED) stored-value:&apos;[ZdsKenmerk(kenmerk=273846, bron=GWS4all)]&apos; , was-value:&apos;null&apos;</string>
+      <string>The field: verlenging does not match (DELETED) stored-value:&apos;ZdsVerlenging(duur=P99D, reden=Overig)&apos; , was-value:&apos;null&apos;</string>
      </void>
      <void property="name">
       <string>Warning</string>
@@ -722,7 +698,7 @@
       <string>nl.haarlem.translations.zdstozgw.translation.zds.services.ZaakService</string>
      </void>
      <void property="threadName">
-      <string>Thread-25</string>
+      <string>http-nio-8080-exec-10</string>
      </void>
      <void property="type">
       <int>6</int>
@@ -747,7 +723,32 @@
       <string>nl.haarlem.translations.zdstozgw.translation.zds.services.ZaakService</string>
      </void>
      <void property="threadName">
-      <string>Thread-25</string>
+      <string>http-nio-8080-exec-10</string>
+     </void>
+     <void property="type">
+      <int>6</int>
+     </void>
+    </object>
+   </void>
+   <void method="add">
+    <object class="nl.nn.testtool.Checkpoint">
+     <void property="level">
+      <int>1</int>
+     </void>
+     <void property="message">
+      <string>The field: kenmerk does not match (DELETED) stored-value:&apos;[ZdsKenmerk(kenmerk=273846, bron=GWS4all)]&apos; , was-value:&apos;null&apos;</string>
+     </void>
+     <void property="name">
+      <string>Warning</string>
+     </void>
+     <void property="report">
+      <object idref="Report0"/>
+     </void>
+     <void property="sourceClassName">
+      <string>nl.haarlem.translations.zdstozgw.translation.zds.services.ZaakService</string>
+     </void>
+     <void property="threadName">
+      <string>http-nio-8080-exec-10</string>
      </void>
      <void property="type">
       <int>6</int>
@@ -772,7 +773,57 @@
       <string>nl.haarlem.translations.zdstozgw.translation.zds.services.ZaakService</string>
      </void>
      <void property="threadName">
-      <string>Thread-25</string>
+      <string>http-nio-8080-exec-10</string>
+     </void>
+     <void property="type">
+      <int>6</int>
+     </void>
+    </object>
+   </void>
+   <void method="add">
+    <object class="nl.nn.testtool.Checkpoint">
+     <void property="level">
+      <int>1</int>
+     </void>
+     <void property="message">
+      <string>The field: registratiedatum does not match (CHANGED) stored-value:&apos;20211228&apos; , was-value:&apos;20210531&apos;</string>
+     </void>
+     <void property="name">
+      <string>Warning</string>
+     </void>
+     <void property="report">
+      <object idref="Report0"/>
+     </void>
+     <void property="sourceClassName">
+      <string>nl.haarlem.translations.zdstozgw.translation.zds.services.ZaakService</string>
+     </void>
+     <void property="threadName">
+      <string>http-nio-8080-exec-10</string>
+     </void>
+     <void property="type">
+      <int>6</int>
+     </void>
+    </object>
+   </void>
+   <void method="add">
+    <object class="nl.nn.testtool.Checkpoint">
+     <void property="level">
+      <int>1</int>
+     </void>
+     <void property="message">
+      <string>The field: startdatum does not match (CHANGED) stored-value:&apos;20211228&apos; , was-value:&apos;20210531&apos;</string>
+     </void>
+     <void property="name">
+      <string>Warning</string>
+     </void>
+     <void property="report">
+      <object idref="Report0"/>
+     </void>
+     <void property="sourceClassName">
+      <string>nl.haarlem.translations.zdstozgw.translation.zds.services.ZaakService</string>
+     </void>
+     <void property="threadName">
+      <string>http-nio-8080-exec-10</string>
      </void>
      <void property="type">
       <int>6</int>
@@ -797,7 +848,7 @@
       <string>nl.haarlem.translations.zdstozgw.translation.zds.services.ZaakService</string>
      </void>
      <void property="threadName">
-      <string>Thread-25</string>
+      <string>http-nio-8080-exec-10</string>
      </void>
      <void property="type">
       <int>6</int>
@@ -856,7 +907,7 @@
     }
   ],
   &quot;entiteittype&quot;: &quot;ZAK&quot;,
-  &quot;identificatie&quot;: &quot;1900135&quot;
+  &quot;identificatie&quot;: &quot;1900322&quot;
 }</string>
      </void>
      <void property="name">
@@ -869,7 +920,7 @@
       <string>nl.haarlem.translations.zdstozgw.debug.ModelMapperAdvice</string>
      </void>
      <void property="threadName">
-      <string>Thread-25</string>
+      <string>http-nio-8080-exec-10</string>
      </void>
      <void property="type">
       <int>1</int>
@@ -883,7 +934,7 @@
      </void>
      <void property="message">
       <string>{
-  &quot;identificatie&quot;: &quot;1900135&quot;,
+  &quot;identificatie&quot;: &quot;1900322&quot;,
   &quot;omschrijving&quot;: &quot;Aanvraag minimaregelingen (Z)&quot;,
   &quot;registratiedatum&quot;: &quot;2021-05-31&quot;,
   &quot;startdatum&quot;: &quot;2021-05-31&quot;
@@ -899,7 +950,7 @@
       <string>nl.haarlem.translations.zdstozgw.debug.ModelMapperAdvice</string>
      </void>
      <void property="threadName">
-      <string>Thread-25</string>
+      <string>http-nio-8080-exec-10</string>
      </void>
      <void property="type">
       <int>2</int>
@@ -912,7 +963,7 @@
       <int>1</int>
      </void>
      <void property="message">
-      <string>{&quot;identificatie&quot;:&quot;1900135&quot;,&quot;bronorganisatie&quot;:&quot;823288444&quot;,&quot;toelichting&quot;:&quot;&quot;,&quot;zaaktype&quot;:&quot;https://fieldlab.westeurope.cloudapp.azure.com/catalogi/api/v1/zaaktypen/d06a9962-a04e-4d64-9c5d-78dbde1a6b8e&quot;,&quot;registratiedatum&quot;:&quot;2021-05-31&quot;,&quot;verantwoordelijkeOrganisatie&quot;:&quot;823288444&quot;,&quot;startdatum&quot;:&quot;2021-05-31&quot;,&quot;einddatumGepland&quot;:&quot;2021-01-01&quot;,&quot;communicatiekanaal&quot;:&quot;&quot;,&quot;productenOfDiensten&quot;:[],&quot;vertrouwelijkheidaanduiding&quot;:&quot;vertrouwelijk&quot;,&quot;betalingsindicatie&quot;:&quot;&quot;,&quot;opschorting&quot;:{&quot;indicatie&quot;:true,&quot;reden&quot;:&quot;niet tijdig verstrekken inform&quot;},&quot;selectielijstklasse&quot;:&quot;&quot;,&quot;relevanteAndereZaken&quot;:[],&quot;kenmerken&quot;:[{&quot;kenmerk&quot;:&quot;273846&quot;,&quot;bron&quot;:&quot;GWS4all&quot;}],&quot;archiefnominatie&quot;:&quot;vernietigen&quot;,&quot;archiefstatus&quot;:&quot;nog_te_archiveren&quot;}</string>
+      <string>{&quot;identificatie&quot;:&quot;1900322&quot;,&quot;bronorganisatie&quot;:&quot;823288444&quot;,&quot;toelichting&quot;:&quot;&quot;,&quot;zaaktype&quot;:&quot;http://localhost:8000/catalogi/api/v1/zaaktypen/0794b397-f7fb-49d8-8657-8c9a75405757&quot;,&quot;registratiedatum&quot;:&quot;2021-05-31&quot;,&quot;verantwoordelijkeOrganisatie&quot;:&quot;823288444&quot;,&quot;startdatum&quot;:&quot;2021-05-31&quot;,&quot;einddatumGepland&quot;:&quot;2021-01-01&quot;,&quot;communicatiekanaal&quot;:&quot;&quot;,&quot;productenOfDiensten&quot;:[],&quot;vertrouwelijkheidaanduiding&quot;:&quot;vertrouwelijk&quot;,&quot;betalingsindicatie&quot;:&quot;&quot;,&quot;verlenging&quot;:{&quot;reden&quot;:&quot;Overig&quot;,&quot;duur&quot;:&quot;P99D&quot;},&quot;selectielijstklasse&quot;:&quot;&quot;,&quot;relevanteAndereZaken&quot;:[],&quot;kenmerken&quot;:[{&quot;kenmerk&quot;:&quot;273846&quot;,&quot;bron&quot;:&quot;GWS4all&quot;}],&quot;archiefnominatie&quot;:&quot;vernietigen&quot;,&quot;archiefstatus&quot;:&quot;nog_te_archiveren&quot;}</string>
      </void>
      <void property="name">
       <string>ZGWClient PUT</string>
@@ -924,7 +975,7 @@
       <string>nl.haarlem.translations.zdstozgw.translation.zgw.client.ZGWClient</string>
      </void>
      <void property="threadName">
-      <string>Thread-25</string>
+      <string>http-nio-8080-exec-10</string>
      </void>
      <void property="type">
       <int>1</int>
@@ -937,7 +988,7 @@
       <int>2</int>
      </void>
      <void property="message">
-      <string>https://test.openzaak.nl/zaken/api/v1/zaken/129d2dc5-2d3a-4cdf-9b09-1c5c0041c946</string>
+      <string>http://localhost:8000/zaken/api/v1/zaken/a1e2e3b5-b1c7-479c-9238-c1b1132c26ec</string>
      </void>
      <void property="name">
       <string>url</string>
@@ -949,7 +1000,7 @@
       <string>nl.haarlem.translations.zdstozgw.translation.zgw.client.ZGWClient</string>
      </void>
      <void property="threadName">
-      <string>Thread-25</string>
+      <string>http-nio-8080-exec-10</string>
      </void>
      <void property="type">
       <int>4</int>
@@ -962,7 +1013,7 @@
       <int>2</int>
      </void>
      <void property="message">
-      <string>{&quot;url&quot;:&quot;https://fieldlab.westeurope.cloudapp.azure.com/zaken/api/v1/zaken/129d2dc5-2d3a-4cdf-9b09-1c5c0041c946&quot;,&quot;uuid&quot;:&quot;129d2dc5-2d3a-4cdf-9b09-1c5c0041c946&quot;,&quot;identificatie&quot;:&quot;1900135&quot;,&quot;bronorganisatie&quot;:&quot;823288444&quot;,&quot;omschrijving&quot;:&quot;Aanvraag minimaregelingen (Z)&quot;,&quot;toelichting&quot;:&quot;&quot;,&quot;zaaktype&quot;:&quot;https://fieldlab.westeurope.cloudapp.azure.com/catalogi/api/v1/zaaktypen/d06a9962-a04e-4d64-9c5d-78dbde1a6b8e&quot;,&quot;registratiedatum&quot;:&quot;2021-05-31&quot;,&quot;verantwoordelijkeOrganisatie&quot;:&quot;823288444&quot;,&quot;startdatum&quot;:&quot;2021-05-31&quot;,&quot;einddatum&quot;:null,&quot;einddatumGepland&quot;:&quot;2021-01-01&quot;,&quot;uiterlijkeEinddatumAfdoening&quot;:null,&quot;publicatiedatum&quot;:null,&quot;communicatiekanaal&quot;:&quot;&quot;,&quot;productenOfDiensten&quot;:[],&quot;vertrouwelijkheidaanduiding&quot;:&quot;vertrouwelijk&quot;,&quot;betalingsindicatie&quot;:&quot;&quot;,&quot;betalingsindicatieWeergave&quot;:&quot;&quot;,&quot;laatsteBetaaldatum&quot;:null,&quot;zaakgeometrie&quot;:null,&quot;verlenging&quot;:{&quot;reden&quot;:&quot;&quot;,&quot;duur&quot;:null},&quot;opschorting&quot;:{&quot;indicatie&quot;:true,&quot;reden&quot;:&quot;niet tijdig verstrekken inform&quot;},&quot;selectielijstklasse&quot;:&quot;&quot;,&quot;hoofdzaak&quot;:null,&quot;deelzaken&quot;:[],&quot;relevanteAndereZaken&quot;:[],&quot;eigenschappen&quot;:[],&quot;status&quot;:&quot;https://fieldlab.westeurope.cloudapp.azure.com/zaken/api/v1/statussen/1ea14e1b-5e10-4769-ae52-fff6bebda89a&quot;,&quot;kenmerken&quot;:[{&quot;kenmerk&quot;:&quot;273846&quot;,&quot;bron&quot;:&quot;GWS4all&quot;}],&quot;archiefnominatie&quot;:&quot;vernietigen&quot;,&quot;archiefstatus&quot;:&quot;nog_te_archiveren&quot;,&quot;archiefactiedatum&quot;:null,&quot;resultaat&quot;:null}</string>
+      <string>{&quot;url&quot;:&quot;http://localhost:8000/zaken/api/v1/zaken/a1e2e3b5-b1c7-479c-9238-c1b1132c26ec&quot;,&quot;uuid&quot;:&quot;a1e2e3b5-b1c7-479c-9238-c1b1132c26ec&quot;,&quot;identificatie&quot;:&quot;1900322&quot;,&quot;bronorganisatie&quot;:&quot;823288444&quot;,&quot;omschrijving&quot;:&quot;Aanvraag minimaregelingen (Z)&quot;,&quot;toelichting&quot;:&quot;&quot;,&quot;zaaktype&quot;:&quot;http://localhost:8000/catalogi/api/v1/zaaktypen/0794b397-f7fb-49d8-8657-8c9a75405757&quot;,&quot;registratiedatum&quot;:&quot;2021-05-31&quot;,&quot;verantwoordelijkeOrganisatie&quot;:&quot;823288444&quot;,&quot;startdatum&quot;:&quot;2021-05-31&quot;,&quot;einddatum&quot;:null,&quot;einddatumGepland&quot;:&quot;2021-01-01&quot;,&quot;uiterlijkeEinddatumAfdoening&quot;:null,&quot;publicatiedatum&quot;:null,&quot;communicatiekanaal&quot;:&quot;&quot;,&quot;productenOfDiensten&quot;:[],&quot;vertrouwelijkheidaanduiding&quot;:&quot;vertrouwelijk&quot;,&quot;betalingsindicatie&quot;:&quot;&quot;,&quot;betalingsindicatieWeergave&quot;:&quot;&quot;,&quot;laatsteBetaaldatum&quot;:null,&quot;zaakgeometrie&quot;:null,&quot;verlenging&quot;:{&quot;reden&quot;:&quot;Overig&quot;,&quot;duur&quot;:&quot;P99D&quot;},&quot;opschorting&quot;:{&quot;indicatie&quot;:false,&quot;reden&quot;:&quot;&quot;},&quot;selectielijstklasse&quot;:&quot;&quot;,&quot;hoofdzaak&quot;:null,&quot;deelzaken&quot;:[],&quot;relevanteAndereZaken&quot;:[],&quot;eigenschappen&quot;:[],&quot;status&quot;:&quot;http://localhost:8000/zaken/api/v1/statussen/9c2c450b-5560-4d74-bc54-664c1769a53d&quot;,&quot;kenmerken&quot;:[{&quot;kenmerk&quot;:&quot;273846&quot;,&quot;bron&quot;:&quot;GWS4all&quot;}],&quot;archiefnominatie&quot;:&quot;vernietigen&quot;,&quot;archiefstatus&quot;:&quot;nog_te_archiveren&quot;,&quot;archiefactiedatum&quot;:null,&quot;resultaat&quot;:null}</string>
      </void>
      <void property="name">
       <string>ZGWClient PUT</string>
@@ -977,7 +1028,7 @@
       <boolean>true</boolean>
      </void>
      <void property="threadName">
-      <string>Thread-25</string>
+      <string>http-nio-8080-exec-10</string>
      </void>
      <void property="type">
       <int>2</int>
@@ -990,7 +1041,7 @@
       <int>1</int>
      </void>
      <void property="message">
-      <string>PUT to: https://test.openzaak.nl/zaken/api/v1/zaken/129d2dc5-2d3a-4cdf-9b09-1c5c0041c946 took 0 milliseconds</string>
+      <string>PUT to: http://localhost:8000/zaken/api/v1/zaken/a1e2e3b5-b1c7-479c-9238-c1b1132c26ec took 0 milliseconds</string>
      </void>
      <void property="name">
       <string>Duration</string>
@@ -1002,7 +1053,7 @@
       <string>nl.haarlem.translations.zdstozgw.translation.zgw.client.ZGWClient</string>
      </void>
      <void property="threadName">
-      <string>Thread-25</string>
+      <string>http-nio-8080-exec-10</string>
      </void>
      <void property="type">
       <int>6</int>
@@ -1024,7 +1075,7 @@
       <string>nl.haarlem.translations.zdstozgw.translation.zgw.client.ZGWClient</string>
      </void>
      <void property="threadName">
-      <string>Thread-25</string>
+      <string>http-nio-8080-exec-10</string>
      </void>
      <void property="type">
       <int>1</int>
@@ -1037,7 +1088,7 @@
       <int>2</int>
      </void>
      <void property="message">
-      <string>https://fieldlab.westeurope.cloudapp.azure.com/catalogi/api/v1/resultaattypen/26e4726d-3b82-4c2d-b6f1-85fe811c63a2</string>
+      <string>http://localhost:8000/zaken/api/v1/statussen?zaak=http://localhost:8000/zaken/api/v1/zaken/a1e2e3b5-b1c7-479c-9238-c1b1132c26ec</string>
      </void>
      <void property="name">
       <string>url</string>
@@ -1049,7 +1100,7 @@
       <string>nl.haarlem.translations.zdstozgw.translation.zgw.client.ZGWClient</string>
      </void>
      <void property="threadName">
-      <string>Thread-25</string>
+      <string>http-nio-8080-exec-10</string>
      </void>
      <void property="type">
       <int>4</int>
@@ -1062,407 +1113,7 @@
       <int>2</int>
      </void>
      <void property="message">
-      <string>{&quot;url&quot;:&quot;https://fieldlab.westeurope.cloudapp.azure.com/catalogi/api/v1/resultaattypen/26e4726d-3b82-4c2d-b6f1-85fe811c63a2&quot;,&quot;zaaktype&quot;:&quot;https://fieldlab.westeurope.cloudapp.azure.com/catalogi/api/v1/zaaktypen/d06a9962-a04e-4d64-9c5d-78dbde1a6b8e&quot;,&quot;omschrijving&quot;:&quot;Afgebroken&quot;,&quot;resultaattypeomschrijving&quot;:&quot;https://referentielijsten-api.vng.cloud/api/v1/resultaattypeomschrijvingen/e6a0c939-3404-45b0-88e3-76c94fb80ea7&quot;,&quot;omschrijvingGeneriek&quot;:&quot;Afgewezen&quot;,&quot;selectielijstklasse&quot;:&quot;https://referentielijsten-api.vng.cloud/api/v1/resultaten/cc5ae4e3-a9e6-4386-bcee-46be4986a829&quot;,&quot;toelichting&quot;:&quot;&quot;,&quot;archiefnominatie&quot;:&quot;vernietigen&quot;,&quot;archiefactietermijn&quot;:&quot;P10Y&quot;,&quot;brondatumArchiefprocedure&quot;:{&quot;afleidingswijze&quot;:&quot;afgehandeld&quot;,&quot;datumkenmerk&quot;:&quot;&quot;,&quot;einddatumBekend&quot;:false,&quot;objecttype&quot;:&quot;&quot;,&quot;registratie&quot;:&quot;&quot;,&quot;procestermijn&quot;:null}}</string>
-     </void>
-     <void property="name">
-      <string>ZGWClient GET</string>
-     </void>
-     <void property="report">
-      <object idref="Report0"/>
-     </void>
-     <void property="sourceClassName">
-      <string>nl.haarlem.translations.zdstozgw.translation.zgw.client.ZGWClient</string>
-     </void>
-     <void property="stubbed">
-      <boolean>true</boolean>
-     </void>
-     <void property="threadName">
-      <string>Thread-25</string>
-     </void>
-     <void property="type">
-      <int>2</int>
-     </void>
-    </object>
-   </void>
-   <void method="add">
-    <object class="nl.nn.testtool.Checkpoint">
-     <void property="level">
-      <int>1</int>
-     </void>
-     <void property="message">
-      <string>GET to: https://fieldlab.westeurope.cloudapp.azure.com/catalogi/api/v1/resultaattypen/26e4726d-3b82-4c2d-b6f1-85fe811c63a2 took 0 milliseconds</string>
-     </void>
-     <void property="name">
-      <string>Duration</string>
-     </void>
-     <void property="report">
-      <object idref="Report0"/>
-     </void>
-     <void property="sourceClassName">
-      <string>nl.haarlem.translations.zdstozgw.translation.zgw.client.ZGWClient</string>
-     </void>
-     <void property="threadName">
-      <string>Thread-25</string>
-     </void>
-     <void property="type">
-      <int>6</int>
-     </void>
-    </object>
-   </void>
-   <void method="add">
-    <object class="nl.nn.testtool.Checkpoint">
-     <void property="level">
-      <int>1</int>
-     </void>
-     <void property="name">
-      <string>ZGWClient GET</string>
-     </void>
-     <void property="report">
-      <object idref="Report0"/>
-     </void>
-     <void property="sourceClassName">
-      <string>nl.haarlem.translations.zdstozgw.translation.zgw.client.ZGWClient</string>
-     </void>
-     <void property="threadName">
-      <string>Thread-25</string>
-     </void>
-     <void property="type">
-      <int>1</int>
-     </void>
-    </object>
-   </void>
-   <void method="add">
-    <object class="nl.nn.testtool.Checkpoint">
-     <void property="level">
-      <int>2</int>
-     </void>
-     <void property="message">
-      <string>https://fieldlab.westeurope.cloudapp.azure.com/catalogi/api/v1/resultaattypen/5236ff3b-aad5-47de-81b9-fe5b46cc22e2</string>
-     </void>
-     <void property="name">
-      <string>url</string>
-     </void>
-     <void property="report">
-      <object idref="Report0"/>
-     </void>
-     <void property="sourceClassName">
-      <string>nl.haarlem.translations.zdstozgw.translation.zgw.client.ZGWClient</string>
-     </void>
-     <void property="threadName">
-      <string>Thread-25</string>
-     </void>
-     <void property="type">
-      <int>4</int>
-     </void>
-    </object>
-   </void>
-   <void method="add">
-    <object class="nl.nn.testtool.Checkpoint">
-     <void property="level">
-      <int>2</int>
-     </void>
-     <void property="message">
-      <string>{&quot;url&quot;:&quot;https://fieldlab.westeurope.cloudapp.azure.com/catalogi/api/v1/resultaattypen/5236ff3b-aad5-47de-81b9-fe5b46cc22e2&quot;,&quot;zaaktype&quot;:&quot;https://fieldlab.westeurope.cloudapp.azure.com/catalogi/api/v1/zaaktypen/d06a9962-a04e-4d64-9c5d-78dbde1a6b8e&quot;,&quot;omschrijving&quot;:&quot;Afgewezen&quot;,&quot;resultaattypeomschrijving&quot;:&quot;https://referentielijsten-api.vng.cloud/api/v1/resultaattypeomschrijvingen/e6a0c939-3404-45b0-88e3-76c94fb80ea7&quot;,&quot;omschrijvingGeneriek&quot;:&quot;Afgewezen&quot;,&quot;selectielijstklasse&quot;:&quot;https://referentielijsten-api.vng.cloud/api/v1/resultaten/cc5ae4e3-a9e6-4386-bcee-46be4986a829&quot;,&quot;toelichting&quot;:&quot;&quot;,&quot;archiefnominatie&quot;:&quot;vernietigen&quot;,&quot;archiefactietermijn&quot;:&quot;P10Y&quot;,&quot;brondatumArchiefprocedure&quot;:{&quot;afleidingswijze&quot;:&quot;afgehandeld&quot;,&quot;datumkenmerk&quot;:&quot;&quot;,&quot;einddatumBekend&quot;:false,&quot;objecttype&quot;:&quot;&quot;,&quot;registratie&quot;:&quot;&quot;,&quot;procestermijn&quot;:null}}</string>
-     </void>
-     <void property="name">
-      <string>ZGWClient GET</string>
-     </void>
-     <void property="report">
-      <object idref="Report0"/>
-     </void>
-     <void property="sourceClassName">
-      <string>nl.haarlem.translations.zdstozgw.translation.zgw.client.ZGWClient</string>
-     </void>
-     <void property="stubbed">
-      <boolean>true</boolean>
-     </void>
-     <void property="threadName">
-      <string>Thread-25</string>
-     </void>
-     <void property="type">
-      <int>2</int>
-     </void>
-    </object>
-   </void>
-   <void method="add">
-    <object class="nl.nn.testtool.Checkpoint">
-     <void property="level">
-      <int>1</int>
-     </void>
-     <void property="message">
-      <string>GET to: https://fieldlab.westeurope.cloudapp.azure.com/catalogi/api/v1/resultaattypen/5236ff3b-aad5-47de-81b9-fe5b46cc22e2 took 0 milliseconds</string>
-     </void>
-     <void property="name">
-      <string>Duration</string>
-     </void>
-     <void property="report">
-      <object idref="Report0"/>
-     </void>
-     <void property="sourceClassName">
-      <string>nl.haarlem.translations.zdstozgw.translation.zgw.client.ZGWClient</string>
-     </void>
-     <void property="threadName">
-      <string>Thread-25</string>
-     </void>
-     <void property="type">
-      <int>6</int>
-     </void>
-    </object>
-   </void>
-   <void method="add">
-    <object class="nl.nn.testtool.Checkpoint">
-     <void property="level">
-      <int>1</int>
-     </void>
-     <void property="name">
-      <string>ZGWClient GET</string>
-     </void>
-     <void property="report">
-      <object idref="Report0"/>
-     </void>
-     <void property="sourceClassName">
-      <string>nl.haarlem.translations.zdstozgw.translation.zgw.client.ZGWClient</string>
-     </void>
-     <void property="threadName">
-      <string>Thread-25</string>
-     </void>
-     <void property="type">
-      <int>1</int>
-     </void>
-    </object>
-   </void>
-   <void method="add">
-    <object class="nl.nn.testtool.Checkpoint">
-     <void property="level">
-      <int>2</int>
-     </void>
-     <void property="message">
-      <string>https://fieldlab.westeurope.cloudapp.azure.com/catalogi/api/v1/resultaattypen/cd6726a2-0fdd-4b6d-ba1c-8cc5dee185ac</string>
-     </void>
-     <void property="name">
-      <string>url</string>
-     </void>
-     <void property="report">
-      <object idref="Report0"/>
-     </void>
-     <void property="sourceClassName">
-      <string>nl.haarlem.translations.zdstozgw.translation.zgw.client.ZGWClient</string>
-     </void>
-     <void property="threadName">
-      <string>Thread-25</string>
-     </void>
-     <void property="type">
-      <int>4</int>
-     </void>
-    </object>
-   </void>
-   <void method="add">
-    <object class="nl.nn.testtool.Checkpoint">
-     <void property="level">
-      <int>2</int>
-     </void>
-     <void property="message">
-      <string>{&quot;url&quot;:&quot;https://fieldlab.westeurope.cloudapp.azure.com/catalogi/api/v1/resultaattypen/cd6726a2-0fdd-4b6d-ba1c-8cc5dee185ac&quot;,&quot;zaaktype&quot;:&quot;https://fieldlab.westeurope.cloudapp.azure.com/catalogi/api/v1/zaaktypen/d06a9962-a04e-4d64-9c5d-78dbde1a6b8e&quot;,&quot;omschrijving&quot;:&quot;Toegekend&quot;,&quot;resultaattypeomschrijving&quot;:&quot;https://referentielijsten-api.vng.cloud/api/v1/resultaattypeomschrijvingen/e6a0c939-3404-45b0-88e3-76c94fb80ea7&quot;,&quot;omschrijvingGeneriek&quot;:&quot;Afgewezen&quot;,&quot;selectielijstklasse&quot;:&quot;https://referentielijsten-api.vng.cloud/api/v1/resultaten/cc5ae4e3-a9e6-4386-bcee-46be4986a829&quot;,&quot;toelichting&quot;:&quot;&quot;,&quot;archiefnominatie&quot;:&quot;vernietigen&quot;,&quot;archiefactietermijn&quot;:&quot;P10Y&quot;,&quot;brondatumArchiefprocedure&quot;:{&quot;afleidingswijze&quot;:&quot;afgehandeld&quot;,&quot;datumkenmerk&quot;:&quot;&quot;,&quot;einddatumBekend&quot;:false,&quot;objecttype&quot;:&quot;&quot;,&quot;registratie&quot;:&quot;&quot;,&quot;procestermijn&quot;:null}}</string>
-     </void>
-     <void property="name">
-      <string>ZGWClient GET</string>
-     </void>
-     <void property="report">
-      <object idref="Report0"/>
-     </void>
-     <void property="sourceClassName">
-      <string>nl.haarlem.translations.zdstozgw.translation.zgw.client.ZGWClient</string>
-     </void>
-     <void property="stubbed">
-      <boolean>true</boolean>
-     </void>
-     <void property="threadName">
-      <string>Thread-25</string>
-     </void>
-     <void property="type">
-      <int>2</int>
-     </void>
-    </object>
-   </void>
-   <void method="add">
-    <object class="nl.nn.testtool.Checkpoint">
-     <void property="level">
-      <int>1</int>
-     </void>
-     <void property="message">
-      <string>GET to: https://fieldlab.westeurope.cloudapp.azure.com/catalogi/api/v1/resultaattypen/cd6726a2-0fdd-4b6d-ba1c-8cc5dee185ac took 0 milliseconds</string>
-     </void>
-     <void property="name">
-      <string>Duration</string>
-     </void>
-     <void property="report">
-      <object idref="Report0"/>
-     </void>
-     <void property="sourceClassName">
-      <string>nl.haarlem.translations.zdstozgw.translation.zgw.client.ZGWClient</string>
-     </void>
-     <void property="threadName">
-      <string>Thread-25</string>
-     </void>
-     <void property="type">
-      <int>6</int>
-     </void>
-    </object>
-   </void>
-   <void method="add">
-    <object class="nl.nn.testtool.Checkpoint">
-     <void property="level">
-      <int>1</int>
-     </void>
-     <void property="name">
-      <string>ZGWClient GET</string>
-     </void>
-     <void property="report">
-      <object idref="Report0"/>
-     </void>
-     <void property="sourceClassName">
-      <string>nl.haarlem.translations.zdstozgw.translation.zgw.client.ZGWClient</string>
-     </void>
-     <void property="threadName">
-      <string>Thread-25</string>
-     </void>
-     <void property="type">
-      <int>1</int>
-     </void>
-    </object>
-   </void>
-   <void method="add">
-    <object class="nl.nn.testtool.Checkpoint">
-     <void property="level">
-      <int>2</int>
-     </void>
-     <void property="message">
-      <string>https://fieldlab.westeurope.cloudapp.azure.com/catalogi/api/v1/resultaattypen/a82392e8-91a1-4d5c-94be-f3c3b05ee5d5</string>
-     </void>
-     <void property="name">
-      <string>url</string>
-     </void>
-     <void property="report">
-      <object idref="Report0"/>
-     </void>
-     <void property="sourceClassName">
-      <string>nl.haarlem.translations.zdstozgw.translation.zgw.client.ZGWClient</string>
-     </void>
-     <void property="threadName">
-      <string>Thread-25</string>
-     </void>
-     <void property="type">
-      <int>4</int>
-     </void>
-    </object>
-   </void>
-   <void method="add">
-    <object class="nl.nn.testtool.Checkpoint">
-     <void property="level">
-      <int>2</int>
-     </void>
-     <void property="message">
-      <string>{&quot;url&quot;:&quot;https://fieldlab.westeurope.cloudapp.azure.com/catalogi/api/v1/resultaattypen/a82392e8-91a1-4d5c-94be-f3c3b05ee5d5&quot;,&quot;zaaktype&quot;:&quot;https://fieldlab.westeurope.cloudapp.azure.com/catalogi/api/v1/zaaktypen/d06a9962-a04e-4d64-9c5d-78dbde1a6b8e&quot;,&quot;omschrijving&quot;:&quot;Buiten behandeling g&quot;,&quot;resultaattypeomschrijving&quot;:&quot;https://referentielijsten-api.vng.cloud/api/v1/resultaattypeomschrijvingen/e6a0c939-3404-45b0-88e3-76c94fb80ea7&quot;,&quot;omschrijvingGeneriek&quot;:&quot;Afgewezen&quot;,&quot;selectielijstklasse&quot;:&quot;https://referentielijsten-api.vng.cloud/api/v1/resultaten/cc5ae4e3-a9e6-4386-bcee-46be4986a829&quot;,&quot;toelichting&quot;:&quot;&quot;,&quot;archiefnominatie&quot;:&quot;vernietigen&quot;,&quot;archiefactietermijn&quot;:&quot;P10Y&quot;,&quot;brondatumArchiefprocedure&quot;:{&quot;afleidingswijze&quot;:&quot;afgehandeld&quot;,&quot;datumkenmerk&quot;:&quot;&quot;,&quot;einddatumBekend&quot;:false,&quot;objecttype&quot;:&quot;&quot;,&quot;registratie&quot;:&quot;&quot;,&quot;procestermijn&quot;:null}}</string>
-     </void>
-     <void property="name">
-      <string>ZGWClient GET</string>
-     </void>
-     <void property="report">
-      <object idref="Report0"/>
-     </void>
-     <void property="sourceClassName">
-      <string>nl.haarlem.translations.zdstozgw.translation.zgw.client.ZGWClient</string>
-     </void>
-     <void property="stubbed">
-      <boolean>true</boolean>
-     </void>
-     <void property="threadName">
-      <string>Thread-25</string>
-     </void>
-     <void property="type">
-      <int>2</int>
-     </void>
-    </object>
-   </void>
-   <void method="add">
-    <object class="nl.nn.testtool.Checkpoint">
-     <void property="level">
-      <int>1</int>
-     </void>
-     <void property="message">
-      <string>GET to: https://fieldlab.westeurope.cloudapp.azure.com/catalogi/api/v1/resultaattypen/a82392e8-91a1-4d5c-94be-f3c3b05ee5d5 took 0 milliseconds</string>
-     </void>
-     <void property="name">
-      <string>Duration</string>
-     </void>
-     <void property="report">
-      <object idref="Report0"/>
-     </void>
-     <void property="sourceClassName">
-      <string>nl.haarlem.translations.zdstozgw.translation.zgw.client.ZGWClient</string>
-     </void>
-     <void property="threadName">
-      <string>Thread-25</string>
-     </void>
-     <void property="type">
-      <int>6</int>
-     </void>
-    </object>
-   </void>
-   <void method="add">
-    <object class="nl.nn.testtool.Checkpoint">
-     <void property="level">
-      <int>1</int>
-     </void>
-     <void property="name">
-      <string>ZGWClient GET</string>
-     </void>
-     <void property="report">
-      <object idref="Report0"/>
-     </void>
-     <void property="sourceClassName">
-      <string>nl.haarlem.translations.zdstozgw.translation.zgw.client.ZGWClient</string>
-     </void>
-     <void property="threadName">
-      <string>Thread-25</string>
-     </void>
-     <void property="type">
-      <int>1</int>
-     </void>
-    </object>
-   </void>
-   <void method="add">
-    <object class="nl.nn.testtool.Checkpoint">
-     <void property="level">
-      <int>2</int>
-     </void>
-     <void property="message">
-      <string>https://test.openzaak.nl/zaken/api/v1/resultaten?zaak=https://fieldlab.westeurope.cloudapp.azure.com/zaken/api/v1/zaken/129d2dc5-2d3a-4cdf-9b09-1c5c0041c946</string>
-     </void>
-     <void property="name">
-      <string>url</string>
-     </void>
-     <void property="report">
-      <object idref="Report0"/>
-     </void>
-     <void property="sourceClassName">
-      <string>nl.haarlem.translations.zdstozgw.translation.zgw.client.ZGWClient</string>
-     </void>
-     <void property="threadName">
-      <string>Thread-25</string>
-     </void>
-     <void property="type">
-      <int>4</int>
-     </void>
-    </object>
-   </void>
-   <void method="add">
-    <object class="nl.nn.testtool.Checkpoint">
-     <void property="level">
-      <int>2</int>
-     </void>
-     <void property="message">
-      <string>https://fieldlab.westeurope.cloudapp.azure.com/zaken/api/v1/zaken/129d2dc5-2d3a-4cdf-9b09-1c5c0041c946</string>
+      <string>http://localhost:8000/zaken/api/v1/zaken/a1e2e3b5-b1c7-479c-9238-c1b1132c26ec</string>
      </void>
      <void property="name">
       <string>Parameter zaak</string>
@@ -1474,7 +1125,558 @@
       <string>nl.haarlem.translations.zdstozgw.translation.zgw.client.ZGWClient</string>
      </void>
      <void property="threadName">
-      <string>Thread-25</string>
+      <string>http-nio-8080-exec-10</string>
+     </void>
+     <void property="type">
+      <int>4</int>
+     </void>
+    </object>
+   </void>
+   <void method="add">
+    <object class="nl.nn.testtool.Checkpoint">
+     <void property="level">
+      <int>2</int>
+     </void>
+     <void property="message">
+      <string>{&quot;count&quot;:1,&quot;next&quot;:null,&quot;previous&quot;:null,&quot;results&quot;:[{&quot;url&quot;:&quot;http://localhost:8000/zaken/api/v1/statussen/9c2c450b-5560-4d74-bc54-664c1769a53d&quot;,&quot;uuid&quot;:&quot;9c2c450b-5560-4d74-bc54-664c1769a53d&quot;,&quot;zaak&quot;:&quot;http://localhost:8000/zaken/api/v1/zaken/a1e2e3b5-b1c7-479c-9238-c1b1132c26ec&quot;,&quot;statustype&quot;:&quot;http://localhost:8000/catalogi/api/v1/statustypen/5cce8bb5-1c75-4847-807a-5359dd3e8a71&quot;,&quot;datumStatusGezet&quot;:&quot;2021-12-28T12:30:32.810000Z&quot;,&quot;statustoelichting&quot;:&quot;Ontvangen&quot;}]}</string>
+     </void>
+     <void property="name">
+      <string>ZGWClient GET</string>
+     </void>
+     <void property="report">
+      <object idref="Report0"/>
+     </void>
+     <void property="sourceClassName">
+      <string>nl.haarlem.translations.zdstozgw.translation.zgw.client.ZGWClient</string>
+     </void>
+     <void property="stubbed">
+      <boolean>true</boolean>
+     </void>
+     <void property="threadName">
+      <string>http-nio-8080-exec-10</string>
+     </void>
+     <void property="type">
+      <int>2</int>
+     </void>
+    </object>
+   </void>
+   <void method="add">
+    <object class="nl.nn.testtool.Checkpoint">
+     <void property="level">
+      <int>1</int>
+     </void>
+     <void property="message">
+      <string>GET to: http://localhost:8000/zaken/api/v1/statussen?zaak=http://localhost:8000/zaken/api/v1/zaken/a1e2e3b5-b1c7-479c-9238-c1b1132c26ec took 0 milliseconds</string>
+     </void>
+     <void property="name">
+      <string>Duration</string>
+     </void>
+     <void property="report">
+      <object idref="Report0"/>
+     </void>
+     <void property="sourceClassName">
+      <string>nl.haarlem.translations.zdstozgw.translation.zgw.client.ZGWClient</string>
+     </void>
+     <void property="threadName">
+      <string>http-nio-8080-exec-10</string>
+     </void>
+     <void property="type">
+      <int>6</int>
+     </void>
+    </object>
+   </void>
+   <void method="add">
+    <object class="nl.nn.testtool.Checkpoint">
+     <void property="level">
+      <int>1</int>
+     </void>
+     <void property="name">
+      <string>ZGWClient GET</string>
+     </void>
+     <void property="report">
+      <object idref="Report0"/>
+     </void>
+     <void property="sourceClassName">
+      <string>nl.haarlem.translations.zdstozgw.translation.zgw.client.ZGWClient</string>
+     </void>
+     <void property="threadName">
+      <string>http-nio-8080-exec-10</string>
+     </void>
+     <void property="type">
+      <int>1</int>
+     </void>
+    </object>
+   </void>
+   <void method="add">
+    <object class="nl.nn.testtool.Checkpoint">
+     <void property="level">
+      <int>2</int>
+     </void>
+     <void property="message">
+      <string>http://localhost:8000/catalogi/api/v1/statustypen?zaaktype=http://localhost:8000/catalogi/api/v1/zaaktypen/0794b397-f7fb-49d8-8657-8c9a75405757</string>
+     </void>
+     <void property="name">
+      <string>url</string>
+     </void>
+     <void property="report">
+      <object idref="Report0"/>
+     </void>
+     <void property="sourceClassName">
+      <string>nl.haarlem.translations.zdstozgw.translation.zgw.client.ZGWClient</string>
+     </void>
+     <void property="threadName">
+      <string>http-nio-8080-exec-10</string>
+     </void>
+     <void property="type">
+      <int>4</int>
+     </void>
+    </object>
+   </void>
+   <void method="add">
+    <object class="nl.nn.testtool.Checkpoint">
+     <void property="level">
+      <int>2</int>
+     </void>
+     <void property="message">
+      <string>http://localhost:8000/catalogi/api/v1/zaaktypen/0794b397-f7fb-49d8-8657-8c9a75405757</string>
+     </void>
+     <void property="name">
+      <string>Parameter zaaktype</string>
+     </void>
+     <void property="report">
+      <object idref="Report0"/>
+     </void>
+     <void property="sourceClassName">
+      <string>nl.haarlem.translations.zdstozgw.translation.zgw.client.ZGWClient</string>
+     </void>
+     <void property="threadName">
+      <string>http-nio-8080-exec-10</string>
+     </void>
+     <void property="type">
+      <int>4</int>
+     </void>
+    </object>
+   </void>
+   <void method="add">
+    <object class="nl.nn.testtool.Checkpoint">
+     <void property="level">
+      <int>2</int>
+     </void>
+     <void property="message">
+      <string>{&quot;count&quot;:7,&quot;next&quot;:null,&quot;previous&quot;:null,&quot;results&quot;:[{&quot;url&quot;:&quot;http://localhost:8000/catalogi/api/v1/statustypen/5cce8bb5-1c75-4847-807a-5359dd3e8a71&quot;,&quot;omschrijving&quot;:&quot;Ontvangen&quot;,&quot;omschrijvingGeneriek&quot;:&quot;Ontvangen&quot;,&quot;statustekst&quot;:&quot;&quot;,&quot;zaaktype&quot;:&quot;http://localhost:8000/catalogi/api/v1/zaaktypen/0794b397-f7fb-49d8-8657-8c9a75405757&quot;,&quot;volgnummer&quot;:1,&quot;isEindstatus&quot;:false,&quot;informeren&quot;:false},{&quot;url&quot;:&quot;http://localhost:8000/catalogi/api/v1/statustypen/98b30f4c-98c3-4a24-a04a-51f909aeb972&quot;,&quot;omschrijving&quot;:&quot;Geaccepteerd&quot;,&quot;omschrijvingGeneriek&quot;:&quot;Geaccepteerd&quot;,&quot;statustekst&quot;:&quot;&quot;,&quot;zaaktype&quot;:&quot;http://localhost:8000/catalogi/api/v1/zaaktypen/0794b397-f7fb-49d8-8657-8c9a75405757&quot;,&quot;volgnummer&quot;:2,&quot;isEindstatus&quot;:false,&quot;informeren&quot;:false},{&quot;url&quot;:&quot;http://localhost:8000/catalogi/api/v1/statustypen/20372f07-f89d-4517-9a0c-8ebf001a0b1d&quot;,&quot;omschrijving&quot;:&quot;In behandeling genomen&quot;,&quot;omschrijvingGeneriek&quot;:&quot;In behandeling genomen&quot;,&quot;statustekst&quot;:&quot;&quot;,&quot;zaaktype&quot;:&quot;http://localhost:8000/catalogi/api/v1/zaaktypen/0794b397-f7fb-49d8-8657-8c9a75405757&quot;,&quot;volgnummer&quot;:3,&quot;isEindstatus&quot;:false,&quot;informeren&quot;:false},{&quot;url&quot;:&quot;http://localhost:8000/catalogi/api/v1/statustypen/a0aa3459-5305-499a-a1dd-c090ea44da38&quot;,&quot;omschrijving&quot;:&quot;Onderzoek afgerond&quot;,&quot;omschrijvingGeneriek&quot;:&quot;Onderzoek afgerond&quot;,&quot;statustekst&quot;:&quot;&quot;,&quot;zaaktype&quot;:&quot;http://localhost:8000/catalogi/api/v1/zaaktypen/0794b397-f7fb-49d8-8657-8c9a75405757&quot;,&quot;volgnummer&quot;:5,&quot;isEindstatus&quot;:false,&quot;informeren&quot;:false},{&quot;url&quot;:&quot;http://localhost:8000/catalogi/api/v1/statustypen/4c5ab517-d89c-4048-983b-ad4333edeee2&quot;,&quot;omschrijving&quot;:&quot;Voorstel voor besluitvorming opgesteld&quot;,&quot;omschrijvingGeneriek&quot;:&quot;Voorstel voor besluitvorming opgesteld&quot;,&quot;statustekst&quot;:&quot;&quot;,&quot;zaaktype&quot;:&quot;http://localhost:8000/catalogi/api/v1/zaaktypen/0794b397-f7fb-49d8-8657-8c9a75405757&quot;,&quot;volgnummer&quot;:6,&quot;isEindstatus&quot;:false,&quot;informeren&quot;:false},{&quot;url&quot;:&quot;http://localhost:8000/catalogi/api/v1/statustypen/d5bf25ba-00c3-4ae5-b273-0b2826474ef2&quot;,&quot;omschrijving&quot;:&quot;Besluitvorming afgerond&quot;,&quot;omschrijvingGeneriek&quot;:&quot;Besluitvorming afgerond&quot;,&quot;statustekst&quot;:&quot;&quot;,&quot;zaaktype&quot;:&quot;http://localhost:8000/catalogi/api/v1/zaaktypen/0794b397-f7fb-49d8-8657-8c9a75405757&quot;,&quot;volgnummer&quot;:7,&quot;isEindstatus&quot;:false,&quot;informeren&quot;:false},{&quot;url&quot;:&quot;http://localhost:8000/catalogi/api/v1/statustypen/6cbd5d70-9da8-4481-8503-014578f0a34e&quot;,&quot;omschrijving&quot;:&quot;Afgehandeld&quot;,&quot;omschrijvingGeneriek&quot;:&quot;Afgehandeld&quot;,&quot;statustekst&quot;:&quot;&quot;,&quot;zaaktype&quot;:&quot;http://localhost:8000/catalogi/api/v1/zaaktypen/0794b397-f7fb-49d8-8657-8c9a75405757&quot;,&quot;volgnummer&quot;:10,&quot;isEindstatus&quot;:true,&quot;informeren&quot;:false}]}</string>
+     </void>
+     <void property="name">
+      <string>ZGWClient GET</string>
+     </void>
+     <void property="report">
+      <object idref="Report0"/>
+     </void>
+     <void property="sourceClassName">
+      <string>nl.haarlem.translations.zdstozgw.translation.zgw.client.ZGWClient</string>
+     </void>
+     <void property="stubbed">
+      <boolean>true</boolean>
+     </void>
+     <void property="threadName">
+      <string>http-nio-8080-exec-10</string>
+     </void>
+     <void property="type">
+      <int>2</int>
+     </void>
+    </object>
+   </void>
+   <void method="add">
+    <object class="nl.nn.testtool.Checkpoint">
+     <void property="level">
+      <int>1</int>
+     </void>
+     <void property="message">
+      <string>GET to: http://localhost:8000/catalogi/api/v1/statustypen?zaaktype=http://localhost:8000/catalogi/api/v1/zaaktypen/0794b397-f7fb-49d8-8657-8c9a75405757 took 0 milliseconds</string>
+     </void>
+     <void property="name">
+      <string>Duration</string>
+     </void>
+     <void property="report">
+      <object idref="Report0"/>
+     </void>
+     <void property="sourceClassName">
+      <string>nl.haarlem.translations.zdstozgw.translation.zgw.client.ZGWClient</string>
+     </void>
+     <void property="threadName">
+      <string>http-nio-8080-exec-10</string>
+     </void>
+     <void property="type">
+      <int>6</int>
+     </void>
+    </object>
+   </void>
+   <void method="add">
+    <object class="nl.nn.testtool.Checkpoint">
+     <void property="level">
+      <int>1</int>
+     </void>
+     <void property="message">
+      <string>{
+  &quot;entiteittype&quot;: &quot;ZAKSTT&quot;,
+  &quot;gerelateerde&quot;: {
+    &quot;entiteittype&quot;: &quot;STT&quot;,
+    &quot;verwerkingssoort&quot;: &quot;T&quot;,
+    &quot;zktCode&quot;: &quot;B1026&quot;,
+    &quot;zktOmschrijving&quot;: &quot;Aanvraag minima&quot;,
+    &quot;omschrijving&quot;: &quot;Afgehandeld&quot;,
+    &quot;code&quot;: &quot;Afgehandeld&quot;,
+    &quot;ingangsdatumObject&quot;: &quot;&quot;,
+    &quot;volgnummer&quot;: &quot;0010&quot;
+  },
+  &quot;datumStatusGezet&quot;: &quot;20210531150153528&quot;,
+  &quot;isGezetDoor&quot;: {
+    &quot;entiteittype&quot;: &quot;ZAKSTTBTR&quot;,
+    &quot;gerelateerde&quot;: {
+      &quot;medewerker&quot;: {
+        &quot;entiteittype&quot;: &quot;MDW&quot;,
+        &quot;identificatie&quot;: &quot;012345678901234567890123&quot;,
+        &quot;achternaam&quot;: &quot;G. Bruiker&quot;,
+        &quot;voorletters&quot;: &quot;&quot;
+      }
+    }
+  }
+}</string>
+     </void>
+     <void property="name">
+      <string>ModelMapper ZdsHeeft-&gt;ZgwStatus</string>
+     </void>
+     <void property="report">
+      <object idref="Report0"/>
+     </void>
+     <void property="sourceClassName">
+      <string>nl.haarlem.translations.zdstozgw.debug.ModelMapperAdvice</string>
+     </void>
+     <void property="threadName">
+      <string>http-nio-8080-exec-10</string>
+     </void>
+     <void property="type">
+      <int>1</int>
+     </void>
+    </object>
+   </void>
+   <void method="add">
+    <object class="nl.nn.testtool.Checkpoint">
+     <void property="level">
+      <int>2</int>
+     </void>
+     <void property="message">
+      <string>{
+  &quot;datumStatusGezet&quot;: &quot;2021-05-31T12:56:53.520000Z&quot;
+}</string>
+     </void>
+     <void property="name">
+      <string>ModelMapper ZdsHeeft-&gt;ZgwStatus</string>
+     </void>
+     <void property="report">
+      <object idref="Report0"/>
+     </void>
+     <void property="sourceClassName">
+      <string>nl.haarlem.translations.zdstozgw.debug.ModelMapperAdvice</string>
+     </void>
+     <void property="threadName">
+      <string>http-nio-8080-exec-10</string>
+     </void>
+     <void property="type">
+      <int>2</int>
+     </void>
+    </object>
+   </void>
+   <void method="add">
+    <object class="nl.nn.testtool.Checkpoint">
+     <void property="level">
+      <int>1</int>
+     </void>
+     <void property="name">
+      <string>ZGWClient GET</string>
+     </void>
+     <void property="report">
+      <object idref="Report0"/>
+     </void>
+     <void property="sourceClassName">
+      <string>nl.haarlem.translations.zdstozgw.translation.zgw.client.ZGWClient</string>
+     </void>
+     <void property="threadName">
+      <string>http-nio-8080-exec-10</string>
+     </void>
+     <void property="type">
+      <int>1</int>
+     </void>
+    </object>
+   </void>
+   <void method="add">
+    <object class="nl.nn.testtool.Checkpoint">
+     <void property="level">
+      <int>2</int>
+     </void>
+     <void property="message">
+      <string>http://localhost:8000/zaken/api/v1/statussen?zaak=http://localhost:8000/zaken/api/v1/zaken/a1e2e3b5-b1c7-479c-9238-c1b1132c26ec</string>
+     </void>
+     <void property="name">
+      <string>url</string>
+     </void>
+     <void property="report">
+      <object idref="Report0"/>
+     </void>
+     <void property="sourceClassName">
+      <string>nl.haarlem.translations.zdstozgw.translation.zgw.client.ZGWClient</string>
+     </void>
+     <void property="threadName">
+      <string>http-nio-8080-exec-10</string>
+     </void>
+     <void property="type">
+      <int>4</int>
+     </void>
+    </object>
+   </void>
+   <void method="add">
+    <object class="nl.nn.testtool.Checkpoint">
+     <void property="level">
+      <int>2</int>
+     </void>
+     <void property="message">
+      <string>http://localhost:8000/zaken/api/v1/zaken/a1e2e3b5-b1c7-479c-9238-c1b1132c26ec</string>
+     </void>
+     <void property="name">
+      <string>Parameter zaak</string>
+     </void>
+     <void property="report">
+      <object idref="Report0"/>
+     </void>
+     <void property="sourceClassName">
+      <string>nl.haarlem.translations.zdstozgw.translation.zgw.client.ZGWClient</string>
+     </void>
+     <void property="threadName">
+      <string>http-nio-8080-exec-10</string>
+     </void>
+     <void property="type">
+      <int>4</int>
+     </void>
+    </object>
+   </void>
+   <void method="add">
+    <object class="nl.nn.testtool.Checkpoint">
+     <void property="level">
+      <int>2</int>
+     </void>
+     <void property="message">
+      <string>{&quot;count&quot;:1,&quot;next&quot;:null,&quot;previous&quot;:null,&quot;results&quot;:[{&quot;url&quot;:&quot;http://localhost:8000/zaken/api/v1/statussen/9c2c450b-5560-4d74-bc54-664c1769a53d&quot;,&quot;uuid&quot;:&quot;9c2c450b-5560-4d74-bc54-664c1769a53d&quot;,&quot;zaak&quot;:&quot;http://localhost:8000/zaken/api/v1/zaken/a1e2e3b5-b1c7-479c-9238-c1b1132c26ec&quot;,&quot;statustype&quot;:&quot;http://localhost:8000/catalogi/api/v1/statustypen/5cce8bb5-1c75-4847-807a-5359dd3e8a71&quot;,&quot;datumStatusGezet&quot;:&quot;2021-12-28T12:30:32.810000Z&quot;,&quot;statustoelichting&quot;:&quot;Ontvangen&quot;}]}</string>
+     </void>
+     <void property="name">
+      <string>ZGWClient GET</string>
+     </void>
+     <void property="report">
+      <object idref="Report0"/>
+     </void>
+     <void property="sourceClassName">
+      <string>nl.haarlem.translations.zdstozgw.translation.zgw.client.ZGWClient</string>
+     </void>
+     <void property="stubbed">
+      <boolean>true</boolean>
+     </void>
+     <void property="threadName">
+      <string>http-nio-8080-exec-10</string>
+     </void>
+     <void property="type">
+      <int>2</int>
+     </void>
+    </object>
+   </void>
+   <void method="add">
+    <object class="nl.nn.testtool.Checkpoint">
+     <void property="level">
+      <int>1</int>
+     </void>
+     <void property="message">
+      <string>GET to: http://localhost:8000/zaken/api/v1/statussen?zaak=http://localhost:8000/zaken/api/v1/zaken/a1e2e3b5-b1c7-479c-9238-c1b1132c26ec took 0 milliseconds</string>
+     </void>
+     <void property="name">
+      <string>Duration</string>
+     </void>
+     <void property="report">
+      <object idref="Report0"/>
+     </void>
+     <void property="sourceClassName">
+      <string>nl.haarlem.translations.zdstozgw.translation.zgw.client.ZGWClient</string>
+     </void>
+     <void property="threadName">
+      <string>http-nio-8080-exec-10</string>
+     </void>
+     <void property="type">
+      <int>6</int>
+     </void>
+    </object>
+   </void>
+   <void method="add">
+    <object class="nl.nn.testtool.Checkpoint">
+     <void property="level">
+      <int>1</int>
+     </void>
+     <void property="name">
+      <string>ZGWClient GET</string>
+     </void>
+     <void property="report">
+      <object idref="Report0"/>
+     </void>
+     <void property="sourceClassName">
+      <string>nl.haarlem.translations.zdstozgw.translation.zgw.client.ZGWClient</string>
+     </void>
+     <void property="threadName">
+      <string>http-nio-8080-exec-10</string>
+     </void>
+     <void property="type">
+      <int>1</int>
+     </void>
+    </object>
+   </void>
+   <void method="add">
+    <object class="nl.nn.testtool.Checkpoint">
+     <void property="level">
+      <int>2</int>
+     </void>
+     <void property="message">
+      <string>http://localhost:8000/catalogi/api/v1/resultaattypen/314ba199-e363-4676-8b38-e9daebf31ddd</string>
+     </void>
+     <void property="name">
+      <string>url</string>
+     </void>
+     <void property="report">
+      <object idref="Report0"/>
+     </void>
+     <void property="sourceClassName">
+      <string>nl.haarlem.translations.zdstozgw.translation.zgw.client.ZGWClient</string>
+     </void>
+     <void property="threadName">
+      <string>http-nio-8080-exec-10</string>
+     </void>
+     <void property="type">
+      <int>4</int>
+     </void>
+    </object>
+   </void>
+   <void method="add">
+    <object class="nl.nn.testtool.Checkpoint">
+     <void property="level">
+      <int>2</int>
+     </void>
+     <void property="message">
+      <string>{&quot;url&quot;:&quot;http://localhost:8000/catalogi/api/v1/resultaattypen/314ba199-e363-4676-8b38-e9daebf31ddd&quot;,&quot;zaaktype&quot;:&quot;http://localhost:8000/catalogi/api/v1/zaaktypen/0794b397-f7fb-49d8-8657-8c9a75405757&quot;,&quot;omschrijving&quot;:&quot;Buiten behandeling g&quot;,&quot;resultaattypeomschrijving&quot;:&quot;https://selectielijst.openzaak.nl/api/v1/resultaattypeomschrijvingen/a6a0bd73-262a-401a-b629-9c4a908c69b5&quot;,&quot;omschrijvingGeneriek&quot;:&quot;Ingetrokken&quot;,&quot;selectielijstklasse&quot;:&quot;https://selectielijst.openzaak.nl/api/v1/resultaten/4811c2bc-3255-4cd4-a00a-7ed59223b8b1&quot;,&quot;toelichting&quot;:&quot;&quot;,&quot;archiefnominatie&quot;:&quot;vernietigen&quot;,&quot;archiefactietermijn&quot;:&quot;P1826D&quot;,&quot;brondatumArchiefprocedure&quot;:{&quot;afleidingswijze&quot;:&quot;afgehandeld&quot;,&quot;datumkenmerk&quot;:&quot;&quot;,&quot;einddatumBekend&quot;:false,&quot;objecttype&quot;:&quot;&quot;,&quot;registratie&quot;:&quot;&quot;,&quot;procestermijn&quot;:null}}</string>
+     </void>
+     <void property="name">
+      <string>ZGWClient GET</string>
+     </void>
+     <void property="report">
+      <object idref="Report0"/>
+     </void>
+     <void property="sourceClassName">
+      <string>nl.haarlem.translations.zdstozgw.translation.zgw.client.ZGWClient</string>
+     </void>
+     <void property="stubbed">
+      <boolean>true</boolean>
+     </void>
+     <void property="threadName">
+      <string>http-nio-8080-exec-10</string>
+     </void>
+     <void property="type">
+      <int>2</int>
+     </void>
+    </object>
+   </void>
+   <void method="add">
+    <object class="nl.nn.testtool.Checkpoint">
+     <void property="level">
+      <int>1</int>
+     </void>
+     <void property="message">
+      <string>GET to: http://localhost:8000/catalogi/api/v1/resultaattypen/314ba199-e363-4676-8b38-e9daebf31ddd took 0 milliseconds</string>
+     </void>
+     <void property="name">
+      <string>Duration</string>
+     </void>
+     <void property="report">
+      <object idref="Report0"/>
+     </void>
+     <void property="sourceClassName">
+      <string>nl.haarlem.translations.zdstozgw.translation.zgw.client.ZGWClient</string>
+     </void>
+     <void property="threadName">
+      <string>http-nio-8080-exec-10</string>
+     </void>
+     <void property="type">
+      <int>6</int>
+     </void>
+    </object>
+   </void>
+   <void method="add">
+    <object class="nl.nn.testtool.Checkpoint">
+     <void property="level">
+      <int>1</int>
+     </void>
+     <void property="name">
+      <string>ZGWClient GET</string>
+     </void>
+     <void property="report">
+      <object idref="Report0"/>
+     </void>
+     <void property="sourceClassName">
+      <string>nl.haarlem.translations.zdstozgw.translation.zgw.client.ZGWClient</string>
+     </void>
+     <void property="threadName">
+      <string>http-nio-8080-exec-10</string>
+     </void>
+     <void property="type">
+      <int>1</int>
+     </void>
+    </object>
+   </void>
+   <void method="add">
+    <object class="nl.nn.testtool.Checkpoint">
+     <void property="level">
+      <int>2</int>
+     </void>
+     <void property="message">
+      <string>http://localhost:8000/zaken/api/v1/resultaten?zaak=http://localhost:8000/zaken/api/v1/zaken/a1e2e3b5-b1c7-479c-9238-c1b1132c26ec</string>
+     </void>
+     <void property="name">
+      <string>url</string>
+     </void>
+     <void property="report">
+      <object idref="Report0"/>
+     </void>
+     <void property="sourceClassName">
+      <string>nl.haarlem.translations.zdstozgw.translation.zgw.client.ZGWClient</string>
+     </void>
+     <void property="threadName">
+      <string>http-nio-8080-exec-10</string>
+     </void>
+     <void property="type">
+      <int>4</int>
+     </void>
+    </object>
+   </void>
+   <void method="add">
+    <object class="nl.nn.testtool.Checkpoint">
+     <void property="level">
+      <int>2</int>
+     </void>
+     <void property="message">
+      <string>http://localhost:8000/zaken/api/v1/zaken/a1e2e3b5-b1c7-479c-9238-c1b1132c26ec</string>
+     </void>
+     <void property="name">
+      <string>Parameter zaak</string>
+     </void>
+     <void property="report">
+      <object idref="Report0"/>
+     </void>
+     <void property="sourceClassName">
+      <string>nl.haarlem.translations.zdstozgw.translation.zgw.client.ZGWClient</string>
+     </void>
+     <void property="threadName">
+      <string>http-nio-8080-exec-10</string>
      </void>
      <void property="type">
       <int>4</int>
@@ -1502,7 +1704,7 @@
       <boolean>true</boolean>
      </void>
      <void property="threadName">
-      <string>Thread-25</string>
+      <string>http-nio-8080-exec-10</string>
      </void>
      <void property="type">
       <int>2</int>
@@ -1515,7 +1717,7 @@
       <int>1</int>
      </void>
      <void property="message">
-      <string>GET to: https://test.openzaak.nl/zaken/api/v1/resultaten?zaak=https://fieldlab.westeurope.cloudapp.azure.com/zaken/api/v1/zaken/129d2dc5-2d3a-4cdf-9b09-1c5c0041c946 took 0 milliseconds</string>
+      <string>GET to: http://localhost:8000/zaken/api/v1/resultaten?zaak=http://localhost:8000/zaken/api/v1/zaken/a1e2e3b5-b1c7-479c-9238-c1b1132c26ec took 0 milliseconds</string>
      </void>
      <void property="name">
       <string>Duration</string>
@@ -1527,7 +1729,7 @@
       <string>nl.haarlem.translations.zdstozgw.translation.zgw.client.ZGWClient</string>
      </void>
      <void property="threadName">
-      <string>Thread-25</string>
+      <string>http-nio-8080-exec-10</string>
      </void>
      <void property="type">
       <int>6</int>
@@ -1540,7 +1742,7 @@
       <int>1</int>
      </void>
      <void property="message">
-      <string>{&quot;zaak&quot;:&quot;https://fieldlab.westeurope.cloudapp.azure.com/zaken/api/v1/zaken/129d2dc5-2d3a-4cdf-9b09-1c5c0041c946&quot;,&quot;resultaattype&quot;:&quot;https://fieldlab.westeurope.cloudapp.azure.com/catalogi/api/v1/resultaattypen/a82392e8-91a1-4d5c-94be-f3c3b05ee5d5&quot;,&quot;toelichting&quot;:&quot;Buiten behandeling gesteld&quot;}</string>
+      <string>{&quot;zaak&quot;:&quot;http://localhost:8000/zaken/api/v1/zaken/a1e2e3b5-b1c7-479c-9238-c1b1132c26ec&quot;,&quot;resultaattype&quot;:&quot;http://localhost:8000/catalogi/api/v1/resultaattypen/314ba199-e363-4676-8b38-e9daebf31ddd&quot;,&quot;toelichting&quot;:&quot;Buiten behandeling gesteld&quot;}</string>
      </void>
      <void property="name">
       <string>ZGWClient POST</string>
@@ -1552,7 +1754,7 @@
       <string>nl.haarlem.translations.zdstozgw.translation.zgw.client.ZGWClient</string>
      </void>
      <void property="threadName">
-      <string>Thread-25</string>
+      <string>http-nio-8080-exec-10</string>
      </void>
      <void property="type">
       <int>1</int>
@@ -1565,7 +1767,7 @@
       <int>2</int>
      </void>
      <void property="message">
-      <string>https://test.openzaak.nl/zaken/api/v1/resultaten</string>
+      <string>http://localhost:8000/zaken/api/v1/resultaten</string>
      </void>
      <void property="name">
       <string>url</string>
@@ -1577,7 +1779,7 @@
       <string>nl.haarlem.translations.zdstozgw.translation.zgw.client.ZGWClient</string>
      </void>
      <void property="threadName">
-      <string>Thread-25</string>
+      <string>http-nio-8080-exec-10</string>
      </void>
      <void property="type">
       <int>4</int>
@@ -1590,7 +1792,7 @@
       <int>2</int>
      </void>
      <void property="message">
-      <string>{&quot;url&quot;:&quot;https://fieldlab.westeurope.cloudapp.azure.com/zaken/api/v1/resultaten/5791f779-aa80-49c4-93b4-9e593a349627&quot;,&quot;uuid&quot;:&quot;5791f779-aa80-49c4-93b4-9e593a349627&quot;,&quot;zaak&quot;:&quot;https://fieldlab.westeurope.cloudapp.azure.com/zaken/api/v1/zaken/129d2dc5-2d3a-4cdf-9b09-1c5c0041c946&quot;,&quot;resultaattype&quot;:&quot;https://fieldlab.westeurope.cloudapp.azure.com/catalogi/api/v1/resultaattypen/a82392e8-91a1-4d5c-94be-f3c3b05ee5d5&quot;,&quot;toelichting&quot;:&quot;Buiten behandeling gesteld&quot;}</string>
+      <string>{&quot;url&quot;:&quot;http://localhost:8000/zaken/api/v1/resultaten/39967542-a4d9-491e-8b12-205ff25d2db9&quot;,&quot;uuid&quot;:&quot;39967542-a4d9-491e-8b12-205ff25d2db9&quot;,&quot;zaak&quot;:&quot;http://localhost:8000/zaken/api/v1/zaken/a1e2e3b5-b1c7-479c-9238-c1b1132c26ec&quot;,&quot;resultaattype&quot;:&quot;http://localhost:8000/catalogi/api/v1/resultaattypen/314ba199-e363-4676-8b38-e9daebf31ddd&quot;,&quot;toelichting&quot;:&quot;Buiten behandeling gesteld&quot;}</string>
      </void>
      <void property="name">
       <string>ZGWClient POST</string>
@@ -1605,7 +1807,7 @@
       <boolean>true</boolean>
      </void>
      <void property="threadName">
-      <string>Thread-25</string>
+      <string>http-nio-8080-exec-10</string>
      </void>
      <void property="type">
       <int>2</int>
@@ -1618,7 +1820,7 @@
       <int>1</int>
      </void>
      <void property="message">
-      <string>POST to: https://test.openzaak.nl/zaken/api/v1/resultaten took 0 milliseconds</string>
+      <string>POST to: http://localhost:8000/zaken/api/v1/resultaten took 0 milliseconds</string>
      </void>
      <void property="name">
       <string>Duration</string>
@@ -1630,7 +1832,7 @@
       <string>nl.haarlem.translations.zdstozgw.translation.zgw.client.ZGWClient</string>
      </void>
      <void property="threadName">
-      <string>Thread-25</string>
+      <string>http-nio-8080-exec-10</string>
      </void>
      <void property="type">
       <int>6</int>
@@ -1652,7 +1854,7 @@
       <string>nl.haarlem.translations.zdstozgw.translation.zgw.client.ZGWClient</string>
      </void>
      <void property="threadName">
-      <string>Thread-25</string>
+      <string>http-nio-8080-exec-10</string>
      </void>
      <void property="type">
       <int>1</int>
@@ -1665,7 +1867,7 @@
       <int>2</int>
      </void>
      <void property="message">
-      <string>https://test.openzaak.nl/zaken/api/v1/statussen?zaak=https://fieldlab.westeurope.cloudapp.azure.com/zaken/api/v1/zaken/129d2dc5-2d3a-4cdf-9b09-1c5c0041c946</string>
+      <string>http://localhost:8000/zaken/api/v1/resultaten?zaak=http://localhost:8000/zaken/api/v1/zaken/a1e2e3b5-b1c7-479c-9238-c1b1132c26ec</string>
      </void>
      <void property="name">
       <string>url</string>
@@ -1677,7 +1879,7 @@
       <string>nl.haarlem.translations.zdstozgw.translation.zgw.client.ZGWClient</string>
      </void>
      <void property="threadName">
-      <string>Thread-25</string>
+      <string>http-nio-8080-exec-10</string>
      </void>
      <void property="type">
       <int>4</int>
@@ -1690,7 +1892,7 @@
       <int>2</int>
      </void>
      <void property="message">
-      <string>https://fieldlab.westeurope.cloudapp.azure.com/zaken/api/v1/zaken/129d2dc5-2d3a-4cdf-9b09-1c5c0041c946</string>
+      <string>http://localhost:8000/zaken/api/v1/zaken/a1e2e3b5-b1c7-479c-9238-c1b1132c26ec</string>
      </void>
      <void property="name">
       <string>Parameter zaak</string>
@@ -1702,7 +1904,7 @@
       <string>nl.haarlem.translations.zdstozgw.translation.zgw.client.ZGWClient</string>
      </void>
      <void property="threadName">
-      <string>Thread-25</string>
+      <string>http-nio-8080-exec-10</string>
      </void>
      <void property="type">
       <int>4</int>
@@ -1715,7 +1917,7 @@
       <int>2</int>
      </void>
      <void property="message">
-      <string>{&quot;count&quot;:8,&quot;next&quot;:null,&quot;previous&quot;:null,&quot;results&quot;:[{&quot;url&quot;:&quot;https://fieldlab.westeurope.cloudapp.azure.com/catalogi/api/v1/statustypen/6cd40dd5-0e5d-473e-b656-69d3073c6987&quot;,&quot;omschrijving&quot;:&quot;Afgehandeld&quot;,&quot;omschrijvingGeneriek&quot;:&quot;Afgehandeld&quot;,&quot;statustekst&quot;:&quot;&quot;,&quot;zaaktype&quot;:&quot;https://fieldlab.westeurope.cloudapp.azure.com/catalogi/api/v1/zaaktypen/d06a9962-a04e-4d64-9c5d-78dbde1a6b8e&quot;,&quot;volgnummer&quot;:10,&quot;isEindstatus&quot;:true,&quot;informeren&quot;:false},{&quot;url&quot;:&quot;https://fieldlab.westeurope.cloudapp.azure.com/catalogi/api/v1/statustypen/c5768a87-7725-4c76-8657-24305efb916d&quot;,&quot;omschrijving&quot;:&quot;Ontvangen&quot;,&quot;omschrijvingGeneriek&quot;:&quot;&quot;,&quot;statustekst&quot;:&quot;Deze status markeert dat het startdocument van de zaak is geregistreerd.&quot;,&quot;zaaktype&quot;:&quot;https://fieldlab.westeurope.cloudapp.azure.com/catalogi/api/v1/zaaktypen/d06a9962-a04e-4d64-9c5d-78dbde1a6b8e&quot;,&quot;volgnummer&quot;:1,&quot;isEindstatus&quot;:false,&quot;informeren&quot;:false},{&quot;url&quot;:&quot;https://fieldlab.westeurope.cloudapp.azure.com/catalogi/api/v1/statustypen/9e32f110-e61c-4668-8eed-8bc7792e73ca&quot;,&quot;omschrijving&quot;:&quot;Geaccepteerd&quot;,&quot;omschrijvingGeneriek&quot;:&quot;&quot;,&quot;statustekst&quot;:&quot;Deze status markeert dat de behandelende afdeling de zaak heeft geaccepteerd.&quot;,&quot;zaaktype&quot;:&quot;https://fieldlab.westeurope.cloudapp.azure.com/catalogi/api/v1/zaaktypen/d06a9962-a04e-4d64-9c5d-78dbde1a6b8e&quot;,&quot;volgnummer&quot;:2,&quot;isEindstatus&quot;:false,&quot;informeren&quot;:false},{&quot;url&quot;:&quot;https://fieldlab.westeurope.cloudapp.azure.com/catalogi/api/v1/statustypen/950542a9-957b-40f6-9729-6ee873f83425&quot;,&quot;omschrijving&quot;:&quot;In behandeling genomen&quot;,&quot;omschrijvingGeneriek&quot;:&quot;&quot;,&quot;statustekst&quot;:&quot;Deze status markeert dat de zaak is toegekend aan een behandelaar.&quot;,&quot;zaaktype&quot;:&quot;https://fieldlab.westeurope.cloudapp.azure.com/catalogi/api/v1/zaaktypen/d06a9962-a04e-4d64-9c5d-78dbde1a6b8e&quot;,&quot;volgnummer&quot;:3,&quot;isEindstatus&quot;:false,&quot;informeren&quot;:false},{&quot;url&quot;:&quot;https://fieldlab.westeurope.cloudapp.azure.com/catalogi/api/v1/statustypen/18bcaedc-80d5-4754-a29e-78f2a75069c9&quot;,&quot;omschrijving&quot;:&quot;Onderzoek afgerond&quot;,&quot;omschrijvingGeneriek&quot;:&quot;&quot;,&quot;statustekst&quot;:&quot;Deze status markeert dat de benodigde onderzoeken zijn afgerond.&quot;,&quot;zaaktype&quot;:&quot;https://fieldlab.westeurope.cloudapp.azure.com/catalogi/api/v1/zaaktypen/d06a9962-a04e-4d64-9c5d-78dbde1a6b8e&quot;,&quot;volgnummer&quot;:5,&quot;isEindstatus&quot;:false,&quot;informeren&quot;:false},{&quot;url&quot;:&quot;https://fieldlab.westeurope.cloudapp.azure.com/catalogi/api/v1/statustypen/bc4bb3f8-f819-4939-b5d2-40c99d8d4aa6&quot;,&quot;omschrijving&quot;:&quot;Voorstel voor besluitvorming opgesteld&quot;,&quot;omschrijvingGeneriek&quot;:&quot;&quot;,&quot;statustekst&quot;:&quot;Deze status markeert dat er een concept-besluit is opgesteld.&quot;,&quot;zaaktype&quot;:&quot;https://fieldlab.westeurope.cloudapp.azure.com/catalogi/api/v1/zaaktypen/d06a9962-a04e-4d64-9c5d-78dbde1a6b8e&quot;,&quot;volgnummer&quot;:6,&quot;isEindstatus&quot;:false,&quot;informeren&quot;:false},{&quot;url&quot;:&quot;https://fieldlab.westeurope.cloudapp.azure.com/catalogi/api/v1/statustypen/73aee1e9-59d3-4cdf-a745-ad4cd9609f0e&quot;,&quot;omschrijving&quot;:&quot;Besluitvorming afgerond&quot;,&quot;omschrijvingGeneriek&quot;:&quot;&quot;,&quot;statustekst&quot;:&quot;Deze status markeert dat er een besluit is genomen.&quot;,&quot;zaaktype&quot;:&quot;https://fieldlab.westeurope.cloudapp.azure.com/catalogi/api/v1/zaaktypen/d06a9962-a04e-4d64-9c5d-78dbde1a6b8e&quot;,&quot;volgnummer&quot;:7,&quot;isEindstatus&quot;:false,&quot;informeren&quot;:false},{&quot;url&quot;:&quot;https://fieldlab.westeurope.cloudapp.azure.com/catalogi/api/v1/statustypen/31667f4f-6469-4706-909c-cc0a7dccda2c&quot;,&quot;omschrijving&quot;:&quot;einde&quot;,&quot;omschrijvingGeneriek&quot;:&quot;&quot;,&quot;statustekst&quot;:&quot;&quot;,&quot;zaaktype&quot;:&quot;https://fieldlab.westeurope.cloudapp.azure.com/catalogi/api/v1/zaaktypen/d06a9962-a04e-4d64-9c5d-78dbde1a6b8e&quot;,&quot;volgnummer&quot;:9,&quot;isEindstatus&quot;:false,&quot;informeren&quot;:false}]}</string>
+      <string>{&quot;count&quot;:1,&quot;next&quot;:null,&quot;previous&quot;:null,&quot;results&quot;:[{&quot;url&quot;:&quot;http://localhost:8000/zaken/api/v1/resultaten/39967542-a4d9-491e-8b12-205ff25d2db9&quot;,&quot;uuid&quot;:&quot;39967542-a4d9-491e-8b12-205ff25d2db9&quot;,&quot;zaak&quot;:&quot;http://localhost:8000/zaken/api/v1/zaken/a1e2e3b5-b1c7-479c-9238-c1b1132c26ec&quot;,&quot;resultaattype&quot;:&quot;http://localhost:8000/catalogi/api/v1/resultaattypen/314ba199-e363-4676-8b38-e9daebf31ddd&quot;,&quot;toelichting&quot;:&quot;Buiten behandeling gesteld&quot;}]}</string>
      </void>
      <void property="name">
       <string>ZGWClient GET</string>
@@ -1730,7 +1932,7 @@
       <boolean>true</boolean>
      </void>
      <void property="threadName">
-      <string>Thread-25</string>
+      <string>http-nio-8080-exec-10</string>
      </void>
      <void property="type">
       <int>2</int>
@@ -1743,7 +1945,7 @@
       <int>1</int>
      </void>
      <void property="message">
-      <string>GET to: https://test.openzaak.nl/zaken/api/v1/statussen?zaak=https://fieldlab.westeurope.cloudapp.azure.com/zaken/api/v1/zaken/129d2dc5-2d3a-4cdf-9b09-1c5c0041c946 took 1 milliseconds</string>
+      <string>GET to: http://localhost:8000/zaken/api/v1/resultaten?zaak=http://localhost:8000/zaken/api/v1/zaken/a1e2e3b5-b1c7-479c-9238-c1b1132c26ec took 0 milliseconds</string>
      </void>
      <void property="name">
       <string>Duration</string>
@@ -1755,7 +1957,7 @@
       <string>nl.haarlem.translations.zdstozgw.translation.zgw.client.ZGWClient</string>
      </void>
      <void property="threadName">
-      <string>Thread-25</string>
+      <string>http-nio-8080-exec-10</string>
      </void>
      <void property="type">
       <int>6</int>
@@ -1767,8 +1969,11 @@
      <void property="level">
       <int>1</int>
      </void>
+     <void property="message">
+      <string>{&quot;zaak&quot;:&quot;http://localhost:8000/zaken/api/v1/zaken/a1e2e3b5-b1c7-479c-9238-c1b1132c26ec&quot;,&quot;statustype&quot;:&quot;http://localhost:8000/catalogi/api/v1/statustypen/6cbd5d70-9da8-4481-8503-014578f0a34e&quot;,&quot;datumStatusGezet&quot;:&quot;2021-05-31T00:00:01.000000Z&quot;,&quot;statustoelichting&quot;:&quot;Afgehandeld&quot;}</string>
+     </void>
      <void property="name">
-      <string>ZGWClient GET</string>
+      <string>ZGWClient POST</string>
      </void>
      <void property="report">
       <object idref="Report0"/>
@@ -1777,7 +1982,7 @@
       <string>nl.haarlem.translations.zdstozgw.translation.zgw.client.ZGWClient</string>
      </void>
      <void property="threadName">
-      <string>Thread-25</string>
+      <string>http-nio-8080-exec-10</string>
      </void>
      <void property="type">
       <int>1</int>
@@ -1790,7 +1995,7 @@
       <int>2</int>
      </void>
      <void property="message">
-      <string>https://test.openzaak.nl/catalogi/api/v1/statustypen?zaaktype=https://fieldlab.westeurope.cloudapp.azure.com/catalogi/api/v1/zaaktypen/d06a9962-a04e-4d64-9c5d-78dbde1a6b8e</string>
+      <string>http://localhost:8000/zaken/api/v1/statussen</string>
      </void>
      <void property="name">
       <string>url</string>
@@ -1802,7 +2007,7 @@
       <string>nl.haarlem.translations.zdstozgw.translation.zgw.client.ZGWClient</string>
      </void>
      <void property="threadName">
-      <string>Thread-25</string>
+      <string>http-nio-8080-exec-10</string>
      </void>
      <void property="type">
       <int>4</int>
@@ -1815,32 +2020,10 @@
       <int>2</int>
      </void>
      <void property="message">
-      <string>https://fieldlab.westeurope.cloudapp.azure.com/catalogi/api/v1/zaaktypen/d06a9962-a04e-4d64-9c5d-78dbde1a6b8e</string>
+      <string>{&quot;url&quot;:&quot;http://localhost:8000/zaken/api/v1/statussen/20b2901d-4ad3-4700-854c-c8ba19f999b2&quot;,&quot;uuid&quot;:&quot;20b2901d-4ad3-4700-854c-c8ba19f999b2&quot;,&quot;zaak&quot;:&quot;http://localhost:8000/zaken/api/v1/zaken/a1e2e3b5-b1c7-479c-9238-c1b1132c26ec&quot;,&quot;statustype&quot;:&quot;http://localhost:8000/catalogi/api/v1/statustypen/6cbd5d70-9da8-4481-8503-014578f0a34e&quot;,&quot;datumStatusGezet&quot;:&quot;2021-05-31T00:00:01Z&quot;,&quot;statustoelichting&quot;:&quot;Afgehandeld&quot;}</string>
      </void>
      <void property="name">
-      <string>Parameter zaaktype</string>
-     </void>
-     <void property="report">
-      <object idref="Report0"/>
-     </void>
-     <void property="sourceClassName">
-      <string>nl.haarlem.translations.zdstozgw.translation.zgw.client.ZGWClient</string>
-     </void>
-     <void property="threadName">
-      <string>Thread-25</string>
-     </void>
-     <void property="type">
-      <int>4</int>
-     </void>
-    </object>
-   </void>
-   <void method="add">
-    <object class="nl.nn.testtool.Checkpoint">
-     <void property="level">
-      <int>2</int>
-     </void>
-     <void property="name">
-      <string>ZGWClient GET</string>
+      <string>ZGWClient POST</string>
      </void>
      <void property="report">
       <object idref="Report0"/>
@@ -1852,7 +2035,7 @@
       <boolean>true</boolean>
      </void>
      <void property="threadName">
-      <string>Thread-25</string>
+      <string>http-nio-8080-exec-10</string>
      </void>
      <void property="type">
       <int>2</int>
@@ -1865,7 +2048,7 @@
       <int>1</int>
      </void>
      <void property="message">
-      <string>GET to: https://test.openzaak.nl/catalogi/api/v1/statustypen?zaaktype=https://fieldlab.westeurope.cloudapp.azure.com/catalogi/api/v1/zaaktypen/d06a9962-a04e-4d64-9c5d-78dbde1a6b8e took 0 milliseconds</string>
+      <string>POST to: http://localhost:8000/zaken/api/v1/statussen took 0 milliseconds</string>
      </void>
      <void property="name">
       <string>Duration</string>
@@ -1877,7 +2060,7 @@
       <string>nl.haarlem.translations.zdstozgw.translation.zgw.client.ZGWClient</string>
      </void>
      <void property="threadName">
-      <string>Thread-25</string>
+      <string>http-nio-8080-exec-10</string>
      </void>
      <void property="type">
       <int>6</int>
@@ -1894,8 +2077,8 @@
      </void>
      <void property="message">
       <string>&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot;?&gt;
-&lt;java version=&quot;13.0.2&quot; class=&quot;java.beans.XMLDecoder&quot;&gt;
- &lt;int&gt;500&lt;/int&gt;
+&lt;java version=&quot;11.0.11&quot; class=&quot;java.beans.XMLDecoder&quot;&gt;
+ &lt;int&gt;200&lt;/int&gt;
 &lt;/java&gt;
 </string>
      </void>
@@ -1912,7 +2095,7 @@
       <string>nl.haarlem.translations.zdstozgw.controller.SoapController</string>
      </void>
      <void property="threadName">
-      <string>Thread-25</string>
+      <string>http-nio-8080-exec-10</string>
      </void>
      <void property="type">
       <int>5</int>
@@ -1925,7 +2108,7 @@
       <int>1</int>
      </void>
      <void property="message">
-      <string>zaakidentificatie:1900135</string>
+      <string>zaakidentificatie:1900322</string>
      </void>
      <void property="name">
       <string>kenmerk</string>
@@ -1937,7 +2120,7 @@
       <string>nl.haarlem.translations.zdstozgw.controller.SoapController</string>
      </void>
      <void property="threadName">
-      <string>Thread-25</string>
+      <string>http-nio-8080-exec-10</string>
      </void>
      <void property="type">
       <int>5</int>
@@ -1950,7 +2133,7 @@
       <int>1</int>
      </void>
      <void property="message">
-      <string>Soapaction: http://www.egem.nl/StUF/sector/zkn/0310/updateZaak_Lk01 with kenmerk: &apos;zaakidentificatie:1900135&apos; returned statuscode:500 INTERNAL_SERVER_ERROR and took 64 milliseconds</string>
+      <string>Soapaction: http://www.egem.nl/StUF/sector/zkn/0310/updateZaak_Lk01 with kenmerk: &apos;zaakidentificatie:1900322&apos; returned statuscode:200 OK and took 1493 milliseconds</string>
      </void>
      <void property="name">
       <string>Total duration</string>
@@ -1961,8 +2144,14 @@
      <void property="sourceClassName">
       <string>nl.haarlem.translations.zdstozgw.controller.SoapController</string>
      </void>
+     <void property="stub">
+      <int>1</int>
+     </void>
+     <void property="stubbed">
+      <boolean>true</boolean>
+     </void>
      <void property="threadName">
-      <string>Thread-25</string>
+      <string>http-nio-8080-exec-10</string>
      </void>
      <void property="type">
       <int>6</int>
@@ -1978,124 +2167,23 @@
       <string>&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot;?&gt;&lt;SOAP-ENV:Envelope xmlns:SOAP-ENV=&quot;http://schemas.xmlsoap.org/soap/envelope/&quot;&gt;&#13;
   &lt;SOAP-ENV:Header/&gt;&#13;
   &lt;SOAP-ENV:Body&gt;&#13;
-    &lt;SOAP-ENV:Fault&gt;&#13;
-      &lt;faultcode xmlns:env=&quot;http://www.w3.org/2003/05/soap-envelope&quot;&gt;env:Receiver&lt;/faultcode&gt;&#13;
-      &lt;faultstring&gt;java.lang.NullPointerException&lt;/faultstring&gt;&#13;
-      &lt;detail&gt;&#13;
-        &lt;Fo03Bericht xmlns=&quot;http://www.egem.nl/StUF/StUF0301&quot; xmlns:ns2=&quot;http://www.egem.nl/StUF/sector/zkn/0310&quot;&gt;&#13;
-          &lt;stuurgegevens&gt;&#13;
-            &lt;berichtcode&gt;Fo03&lt;/berichtcode&gt;&#13;
-            &lt;zender&gt;&#13;
-              &lt;organisatie&gt;1900&lt;/organisatie&gt;&#13;
-              &lt;applicatie&gt;CDR&lt;/applicatie&gt;&#13;
-            &lt;/zender&gt;&#13;
-            &lt;ontvanger&gt;&#13;
-              &lt;organisatie&gt;1900&lt;/organisatie&gt;&#13;
-              &lt;applicatie&gt;GWS4all&lt;/applicatie&gt;&#13;
-              &lt;gebruiker&gt;Gebruiker&lt;/gebruiker&gt;&#13;
-            &lt;/ontvanger&gt;&#13;
-            &lt;referentienummer&gt;Ladybug_Test_Tool-2.2-20210518.202847--7055860a:17d78389a27:-7fed&lt;/referentienummer&gt;&#13;
-            &lt;tijdstipBericht&gt;20211201235836&lt;/tijdstipBericht&gt;&#13;
-            &lt;crossRefnummer&gt;ed7c5ec6-8cb6-4e62-a3bd-77973938c18f&lt;/crossRefnummer&gt;&#13;
-          &lt;/stuurgegevens&gt;&#13;
-          &lt;body&gt;&#13;
-            &lt;code&gt;StUF058&lt;/code&gt;&#13;
-            &lt;plek&gt;server&lt;/plek&gt;&#13;
-            &lt;omschrijving&gt;java.lang.NullPointerException&lt;/omschrijving&gt;&#13;
-            &lt;details&gt;java.lang.NullPointerException&amp;#13;&#13;
-	at nl.haarlem.translations.zdstozgw.translation.zgw.client.ZGWClient.getStatusTypes(ZGWClient.java:464)&amp;#13;&#13;
-	at nl.haarlem.translations.zdstozgw.translation.zgw.client.ZGWClient.getStatusTypeByZaakTypeAndOmschrijving(ZGWClient.java:671)&amp;#13;&#13;
-	at nl.haarlem.translations.zdstozgw.translation.zds.services.ZaakService.setResultaatAndStatus(ZaakService.java:413)&amp;#13;&#13;
-	at nl.haarlem.translations.zdstozgw.translation.zds.services.ZaakService.updateZaak(ZaakService.java:343)&amp;#13;&#13;
-	at nl.haarlem.translations.zdstozgw.converter.impl.translate.UpdateZaakTranslator.execute(UpdateZaakTranslator.java:58)&amp;#13;&#13;
-	at nl.haarlem.translations.zdstozgw.requesthandler.RequestHandler.execute(RequestHandler.java:98)&amp;#13;&#13;
-	at nl.haarlem.translations.zdstozgw.controller.SoapController.HandleRequest(SoapController.java:114)&amp;#13;&#13;
-	at nl.haarlem.translations.zdstozgw.debug.Rerunner.rerun(Rerunner.java:72)&amp;#13;&#13;
-	at nl.haarlem.translations.zdstozgw.debug.Rerunner$$FastClassBySpringCGLIB$$ca0b8a6e.invoke(&amp;lt;generated&lt;/details&gt;&#13;
-            &lt;detailsXML&gt;&#13;
-              &lt;todo&gt;&amp;lt;SOAP-ENV:Envelope xsi:schemaLocation=&quot;http://www.egem.nl/StUF/sector/zkn/0310 zkn0310-p28\mutatie\zkn0310_msg_mutatie_resolved.xsd&quot; xmlns:SOAP-ENV=&quot;http://schemas.xmlsoap.org/soap/envelope/&quot; xmlns:BG=&quot;http://www.egem.nl/StUF/sector/bg/0310&quot; xmlns:StUF=&quot;http://www.egem.nl/StUF/StUF0301&quot; xmlns:ZKN=&quot;http://www.egem.nl/StUF/sector/zkn/0310&quot; xmlns:xsi=&quot;http://www.w3.org/2001/XMLSchema-instance&quot;&amp;gt;&amp;#13;&#13;
-   &amp;lt;SOAP-ENV:Header/&amp;gt;&amp;#13;&#13;
-   &amp;lt;SOAP-ENV:Body&amp;gt;&amp;#13;&#13;
-      &amp;lt;ZKN:zakLk01&amp;gt;&amp;#13;&#13;
-         &amp;lt;ZKN:stuurgegevens&amp;gt;&amp;#13;&#13;
-            &amp;lt;StUF:berichtcode&amp;gt;Lk01&amp;lt;/StUF:berichtcode&amp;gt;&amp;#13;&#13;
-            &amp;lt;StUF:zender&amp;gt;&amp;#13;&#13;
-               &amp;lt;StUF:organisatie&amp;gt;1900&amp;lt;/StUF:organisatie&amp;gt;&amp;#13;&#13;
-               &amp;lt;StUF:applicatie&amp;gt;GWS4all&amp;lt;/StUF:applicatie&amp;gt;&amp;#13;&#13;
-               &amp;lt;StUF:gebruiker&amp;gt;Gebruiker&amp;lt;/StUF:gebruiker&amp;gt;&amp;#13;&#13;
-            &amp;lt;/StUF:zender&amp;gt;&amp;#13;&#13;
-            &amp;lt;StUF:ontvanger&amp;gt;&amp;#13;&#13;
-               &amp;lt;StUF:organisatie&amp;gt;1900&amp;lt;/StUF:organisatie&amp;gt;&amp;#13;&#13;
-               &amp;lt;StUF:applicatie&amp;gt;CDR&amp;lt;/StUF:applicatie&amp;gt;&amp;#13;&#13;
-            &amp;lt;/StUF:ontvanger&amp;gt;&amp;#13;&#13;
-            &amp;lt;StUF:referentienummer&amp;gt;ed7c5ec6-8cb6-4e62-a3bd-77973938c18f&amp;lt;/StUF:referentienummer&amp;gt;&amp;#13;&#13;
-            &amp;lt;StUF:tijdstipBericht&amp;gt;20210531150153490&amp;lt;/StUF:tijdstipBericht&amp;gt;&amp;#13;&#13;
-            &amp;lt;StUF:entiteittype&amp;gt;ZAK&amp;lt;/StUF:entiteittype&amp;gt;&amp;#13;&#13;
-         &amp;lt;/ZKN:stuurgegevens&amp;gt;&amp;#13;&#13;
-         &amp;lt;ZKN:parameters&amp;gt;&amp;#13;&#13;
-            &amp;lt;StUF:mutatiesoort&amp;gt;W&amp;lt;/StUF:mutatiesoort&amp;gt;&amp;#13;&#13;
-            &amp;lt;StUF:indicatorOvername&amp;gt;V&amp;lt;/StUF:indicatorOvername&amp;gt;&amp;#13;&#13;
-         &amp;lt;/ZKN:parameters&amp;gt;&amp;#13;&#13;
-         &amp;lt;ZKN:object StUF:sleutelVerzendend=&quot;1900135&quot; StUF:entiteittype=&quot;ZAK&quot; StUF:verwerkingssoort=&quot;W&quot;&amp;gt;&amp;#13;&#13;
-            &amp;lt;ZKN:identificatie&amp;gt;1900135&amp;lt;/ZKN:identificatie&amp;gt;&amp;#13;&#13;
-            &amp;lt;ZKN:omschrijving&amp;gt;Aanvraag minimaregelingen (Z)&amp;lt;/ZKN:omschrijving&amp;gt;&amp;#13;&#13;
-            &amp;lt;ZKN:startdatum&amp;gt;20210531&amp;lt;/ZKN:startdatum&amp;gt;&amp;#13;&#13;
-            &amp;lt;ZKN:registratiedatum&amp;gt;20210531&amp;lt;/ZKN:registratiedatum&amp;gt;&amp;#13;&#13;
-            &amp;lt;ZKN:isVan StUF:entiteittype=&quot;ZAKZKT&quot; StUF:verwerkingssoort=&quot;I&quot;&amp;gt;&amp;#13;&#13;
-               &amp;lt;ZKN:gerelateerde StUF:entiteittype=&quot;ZKT&quot; StUF:verwerkingssoort=&quot;I&quot;&amp;gt;&amp;#13;&#13;
-                  &amp;lt;ZKN:omschrijving&amp;gt;Aanvraag minima&amp;lt;/ZKN:omschrijving&amp;gt;&amp;#13;&#13;
-                  &amp;lt;ZKN:code&amp;gt;B1026&amp;lt;/ZKN:code&amp;gt;&amp;#13;&#13;
-                  &amp;lt;ZKN:ingangsdatumObject xsi:nil=&quot;true&quot; StUF:noValue=&quot;geenWaarde&quot;/&amp;gt;&amp;#13;&#13;
-               &amp;lt;/ZKN:gerelateerde&amp;gt;&amp;#13;&#13;
-            &amp;lt;/ZKN:isVan&amp;gt;&amp;#13;&#13;
-            &amp;lt;ZKN:leidtTot StUF:entiteittype=&quot;ZAKBSL&quot; StUF:verwerkingssoort=&quot;T&quot; xsi:nil=&quot;true&quot; StUF:noValue=&quot;geenWaarde&quot;/&amp;gt;&amp;#13;&#13;
-         &amp;lt;/ZKN:object&amp;gt;&amp;#13;&#13;
-         &amp;lt;ZKN:object StUF:sleutelVerzendend=&quot;1900135&quot; StUF:entiteittype=&quot;ZAK&quot; StUF:verwerkingssoort=&quot;W&quot;&amp;gt;&amp;#13;&#13;
-            &amp;lt;ZKN:identificatie&amp;gt;1900135&amp;lt;/ZKN:identificatie&amp;gt;&amp;#13;&#13;
-            &amp;lt;ZKN:omschrijving&amp;gt;Aanvraag minimaregelingen (Z)&amp;lt;/ZKN:omschrijving&amp;gt;&amp;#13;&#13;
-            &amp;lt;ZKN:resultaat&amp;gt;&amp;#13;&#13;
-               &amp;lt;!-- &amp;lt;ZKN:omschrijving&amp;gt;Toegekend&amp;lt;/ZKN:omschrijving&amp;gt;&amp;#13; --&amp;gt;&#13;
-               &amp;lt;ZKN:omschrijving&amp;gt;Buiten behandeling gesteld&amp;lt;/ZKN:omschrijving&amp;gt;&#13;
-            &amp;lt;/ZKN:resultaat&amp;gt;&amp;#13;&#13;
-            &amp;lt;ZKN:startdatum&amp;gt;20210531&amp;lt;/ZKN:startdatum&amp;gt;&amp;#13;&#13;
-            &amp;lt;ZKN:registratiedatum&amp;gt;20210531&amp;lt;/ZKN:registratiedatum&amp;gt;&amp;#13;&#13;
-            &amp;lt;ZKN:einddatum&amp;gt;20210531&amp;lt;/ZKN:einddatum&amp;gt;&amp;#13;&#13;
-            &amp;lt;ZKN:isVan StUF:entiteittype=&quot;ZAKZKT&quot; StUF:verwerkingssoort=&quot;I&quot;&amp;gt;&amp;#13;&#13;
-               &amp;lt;ZKN:gerelateerde StUF:entiteittype=&quot;ZKT&quot; StUF:verwerkingssoort=&quot;I&quot;&amp;gt;&amp;#13;&#13;
-                  &amp;lt;ZKN:omschrijving&amp;gt;Aanvraag minima&amp;lt;/ZKN:omschrijving&amp;gt;&amp;#13;&#13;
-                  &amp;lt;ZKN:code&amp;gt;B1026&amp;lt;/ZKN:code&amp;gt;&amp;#13;&#13;
-                  &amp;lt;ZKN:ingangsdatumObject xsi:nil=&quot;true&quot; StUF:noValue=&quot;geenWaarde&quot;/&amp;gt;&amp;#13;&#13;
-               &amp;lt;/ZKN:gerelateerde&amp;gt;&amp;#13;&#13;
-            &amp;lt;/ZKN:isVan&amp;gt;&amp;#13;&#13;
-            &amp;lt;ZKN:heeft StUF:entiteittype=&quot;ZAKSTT&quot; StUF:verwerkingssoort=&quot;T&quot;&amp;gt;&#13;
-               &amp;lt;ZKN:gerelateerde StUF:entiteittype=&quot;STT&quot; StUF:verwerkingssoort=&quot;T&quot;&amp;gt;&#13;
-                  &amp;lt;ZKN:zkt.code&amp;gt;B1026&amp;lt;/ZKN:zkt.code&amp;gt;&#13;
-                  &amp;lt;ZKN:zkt.omschrijving&amp;gt;Aanvraag minima&amp;lt;/ZKN:zkt.omschrijving&amp;gt;&#13;
-                  &amp;lt;ZKN:volgnummer&amp;gt;0010&amp;lt;/ZKN:volgnummer&amp;gt;&#13;
-                  &amp;lt;ZKN:code&amp;gt;Afgehandeld&amp;lt;/ZKN:code&amp;gt;&#13;
-                  &amp;lt;ZKN:omschrijving&amp;gt;Afgehandeld&amp;lt;/ZKN:omschrijving&amp;gt;&#13;
-                  &amp;lt;ZKN:ingangsdatumObject xsi:nil=&quot;true&quot; StUF:noValue=&quot;geenWaarde&quot;/&amp;gt;&#13;
-               &amp;lt;/ZKN:gerelateerde&amp;gt;&#13;
-               &amp;lt;ZKN:datumStatusGezet&amp;gt;20210531150153528&amp;lt;/ZKN:datumStatusGezet&amp;gt;&#13;
-               &amp;lt;ZKN:isGezetDoor StUF:entiteittype=&quot;ZAKSTTBTR&quot; StUF:verwerkingssoort=&quot;T&quot;&amp;gt;&#13;
-                  &amp;lt;ZKN:gerelateerde&amp;gt;&#13;
-                     &amp;lt;ZKN:medewerker StUF:entiteittype=&quot;MDW&quot; StUF:verwerkingssoort=&quot;I&quot;&amp;gt;&#13;
-                        &amp;lt;ZKN:identificatie&amp;gt;012345678901234567890123&amp;lt;/ZKN:identificatie&amp;gt;&#13;
-                        &amp;lt;ZKN:achternaam&amp;gt;G. Bruiker&amp;lt;/ZKN:achternaam&amp;gt;&#13;
-                        &amp;lt;ZKN:voorletters xsi:nil=&quot;true&quot; StUF:noValue=&quot;geenWaarde&quot;/&amp;gt;&#13;
-                     &amp;lt;/ZKN:medewerker&amp;gt;&#13;
-                  &amp;lt;/ZKN:gerelateerde&amp;gt;&#13;
-               &amp;lt;/ZKN:isGezetDoor&amp;gt;&#13;
-            &amp;lt;/ZKN:heeft&amp;gt;            &#13;
-         &amp;lt;/ZKN:object&amp;gt;&amp;#13;&#13;
-      &amp;lt;/ZKN:zakLk01&amp;gt;&amp;#13;&#13;
-   &amp;lt;/SOAP-ENV:Body&amp;gt;&amp;#13;&#13;
-&amp;lt;/SOAP-ENV:Envelope&amp;gt;&lt;/todo&gt;&#13;
-            &lt;/detailsXML&gt;&#13;
-          &lt;/body&gt;&#13;
-        &lt;/Fo03Bericht&gt;&#13;
-      &lt;/detail&gt;&#13;
-    &lt;/SOAP-ENV:Fault&gt;&#13;
+    &lt;Bv03Bericht xmlns=&quot;http://www.egem.nl/StUF/StUF0301&quot; xmlns:ns2=&quot;http://www.egem.nl/StUF/sector/zkn/0310&quot;&gt;&#13;
+      &lt;stuurgegevens&gt;&#13;
+        &lt;berichtcode&gt;Bv03&lt;/berichtcode&gt;&#13;
+        &lt;zender&gt;&#13;
+          &lt;organisatie&gt;1900&lt;/organisatie&gt;&#13;
+          &lt;applicatie&gt;CDR&lt;/applicatie&gt;&#13;
+        &lt;/zender&gt;&#13;
+        &lt;ontvanger&gt;&#13;
+          &lt;organisatie&gt;1900&lt;/organisatie&gt;&#13;
+          &lt;applicatie&gt;GWS4all&lt;/applicatie&gt;&#13;
+          &lt;gebruiker&gt;Gebruiker&lt;/gebruiker&gt;&#13;
+        &lt;/ontvanger&gt;&#13;
+        &lt;referentienummer&gt;Ladybug_Test_Tool-2.2-20210518.202847--27fc203d:17e011fd5d0:-7f99&lt;/referentienummer&gt;&#13;
+        &lt;tijdstipBericht&gt;20211228140438&lt;/tijdstipBericht&gt;&#13;
+        &lt;crossRefnummer&gt;ed7c5ec6-8cb6-4e62-a3bd-77973938c18f&lt;/crossRefnummer&gt;&#13;
+      &lt;/stuurgegevens&gt;&#13;
+    &lt;/Bv03Bericht&gt;&#13;
   &lt;/SOAP-ENV:Body&gt;&#13;
 &lt;/SOAP-ENV:Envelope&gt;&#13;
 </string>
@@ -2110,34 +2198,34 @@
       <string>nl.haarlem.translations.zdstozgw.controller.SoapController</string>
      </void>
      <void property="threadName">
-      <string>Thread-25</string>
+      <string>http-nio-8080-exec-10</string>
      </void>
      <void property="type">
-      <int>3</int>
+      <int>2</int>
      </void>
     </object>
    </void>
   </void>
   <void property="correlationId">
-   <string>Ladybug_Test_Tool-2.2-20210518.202847--7055860a:17d78389a27:-7fed</string>
+   <string>Ladybug_Test_Tool-2.2-20210518.202847--27fc203d:17e011fd5d0:-7f99</string>
   </void>
   <void property="description">
    <string></string>
   </void>
   <void property="endTime">
-   <long>1638399516861</long>
+   <long>1640696678824</long>
   </void>
   <void property="name">
    <string>Suites4SociaalDomein 14 Translate updateZaak_Lk01</string>
   </void>
   <void property="path">
-   <string></string>
+   <string>/</string>
   </void>
   <void property="startTime">
-   <long>1638399516797</long>
+   <long>1640696678766</long>
   </void>
   <void property="storageId">
-   <int>482</int>
+   <int>504</int>
   </void>
   <void property="stubStrategy">
    <string>Stub all external connection code</string>


### PR DESCRIPTION
Separated translation logic from the POST actions for statuses. Ensuring the presence of at least 1 resultaat needs information from the translation logic of statuses, but the resultaat needs to be present before an endstatus can be POSTed.

Added injection of a resultaat when the current action is going to close the zaak (contains a status update to the endstatus) and there is no resultaat on the zaak. It injects a resultaat with of the resultaatType from the "BeeindigZaakWanneerEinddatum" mapping.

The scenario of a zds application updating the zaak with the resultaat AFTER an endstatus has closed the zaak, should still work correctly. Resultaat only has a relation with a zaak. It is not part of a zaak and therefor the resultaat can be changed after the zaak is closed. Updating the resultaat after the zaak is closed, will replace the injected resultaat, so a dummy/incorrect resultaattype can be used to inject for this scenario.