### PR TITLE
make nexus push depend on docker checks

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -77,7 +77,7 @@ jobs:
           ./docker_push.sh
 
   publish_package_to_nexus:
-    needs: build_and_test
+    needs: start_docker_container_and_publish_image
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,7 @@ jobs:
           ./docker_push.sh
 
   publish_release_to_nexus:
+    needs: publish_docker_release_image
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Some runtime checks are done on the docker container that should abort the push to nexus when it there is a failure. 