### PR TITLE
Fix issue 351: incorrect translation of soortRechtsvorm

### DIFF
--- a/src/main/java/nl/haarlem/translations/zdstozgw/config/ModelMapperConfig.java
+++ b/src/main/java/nl/haarlem/translations/zdstozgw/config/ModelMapperConfig.java
@@ -26,6 +26,8 @@ import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 
+import nl.haarlem.translations.zdstozgw.translation.zds.model.enumeration.SoortRechtsvorm;
+
 import org.apache.commons.lang.StringUtils;
 import org.modelmapper.AbstractConverter;
 import org.modelmapper.Conditions;
@@ -285,17 +287,12 @@ public class ModelMapperConfig {
 								ZgwBetrokkeneIdentificatie::setGeslachtsaanduiding));
 	}
 
-	public void addZdsNietNatuurlijkPersoonToZgwBetrokkeneIdentificatieTypeMapping(ModelMapper modelMapper) {
-		modelMapper.typeMap(ZdsNietNatuurlijkPersoon.class, ZgwBetrokkeneIdentificatie.class);
-		/*
-				.addMappings(mapper -> mapper.using(convertStufDateToZgwDate())
-						.map(ZdsNatuurlijkPersoon::getGeboortedatum, ZgwBetrokkeneIdentificatie::setGeboortedatum))
-				.addMappings(mapper -> mapper.map(ZdsNatuurlijkPersoon::getBsn, ZgwBetrokkeneIdentificatie::setInpBsn))
-				.addMappings(
-						mapper -> mapper.using(convertToLowerCase()).map(ZdsNatuurlijkPersoon::getGeslachtsaanduiding,
-								ZgwBetrokkeneIdentificatie::setGeslachtsaanduiding));
-		*/
-	}
+    public void addZdsNietNatuurlijkPersoonToZgwBetrokkeneIdentificatieTypeMapping(ModelMapper modelMapper) {
+        modelMapper.typeMap(ZdsNietNatuurlijkPersoon.class, ZgwBetrokkeneIdentificatie.class)
+            .addMappings(
+                mapper -> mapper.using(convertStufRechtsvormToZGWRechtsvorm()).map(ZdsNietNatuurlijkPersoon::getInnRechtsvorm,
+                    ZgwBetrokkeneIdentificatie::setInnRechtsvorm));
+    }
 
 	public void addZdsZaakDocumentToZgwEnkelvoudigInformatieObjectTypeMapping(ModelMapper modelMapper) {
 		modelMapper.typeMap(ZdsZaakDocument.class, ZgwEnkelvoudigInformatieObject.class)
@@ -597,4 +594,20 @@ public class ModelMapperConfig {
 			}
 		};
 	}
+
+
+    private AbstractConverter<String, String> convertStufRechtsvormToZGWRechtsvorm() {
+        return new AbstractConverter<>() {
+            @Override
+            protected String convert(String zdsInnRechtsvorm) {
+                var rechtsvorm = SoortRechtsvorm.getSoortRechtsvorm(zdsInnRechtsvorm);
+                if(rechtsvorm.isPresent()){
+                    return rechtsvorm.get().getZgwInnRechtsvorm();
+                } else {
+                    log.info("[processing warning] Rechtsvorm: '{}' kon niet worden geconverteerd", zdsInnRechtsvorm );
+                    return null;
+                }
+            }
+        };
+    }
 }

--- a/src/main/java/nl/haarlem/translations/zdstozgw/translation/zds/model/enumeration/SoortRechtsvorm.java
+++ b/src/main/java/nl/haarlem/translations/zdstozgw/translation/zds/model/enumeration/SoortRechtsvorm.java
@@ -1,0 +1,44 @@
+package nl.haarlem.translations.zdstozgw.translation.zds.model.enumeration;
+
+import lombok.Getter;
+import java.util.Arrays;
+import java.util.Optional;
+
+@Getter
+public enum SoortRechtsvorm {
+
+    BESLOTEN_VENNOOTSCHAP("Besloten vennootschap","besloten_vennootschap"),
+    EUROPESE_COOPERATIEVE_VENNOOTSCHAP("Europese Cooperatieve Vennootschap","europese_cooperatieve_vennootschap"),
+    EUROPESE_NAAMLOZE_VENNOOTSCHAP("Europese Naamloze Vennootschap","europese_naamloze_vennootschap"),
+    COMMANDITAIRE_VENNOOTSCHAP("commanditaire vennootschap","commanditaire_vennootschap"),
+    COOPERATIEVE_EUROPESCHE_ECONOMISCHE_SAMENWERKING("cooperatie Europees Economische Samenwerking","cooperatie_europees_economische_samenwerking"),
+    KAPITAAL_VENNOOTSCHAP_BINNEN_EER("kapitaalvennootschap binnen EER","kapitaalvennootschap_binnen_eer"),
+    KAPITAAL_VENNOOTSCHAP_BUITEN_EER("kapitaalvennootschap buiten EER","kapitaalvennootschap_buiten_eer"),
+    KERKELIJKE_ORGANISATIE("kerkelijke Organisatie","kerkelijke_organisatie"),
+    MAATSCHAP("maatschap","maatschap"),
+    NAAMLOZE_VENNOOTSCHAP("naamloze Vennootschap","naamloze_vennootschap"),
+    ONDERLINGE_WAARBORG_MAATSCHAPPIJ("onderlinge Waarborg Maatschappij","onderlinge_waarborg_maatschappij"),
+    OVERIG_PRIVAATRECHTELIJKE_RECHTSPERSOON("overig privaatrechtelijke rechtspersoon","overig_privaatrechtelijke_rechtspersoon"),
+    OVERIGE_BUITENLANDSE_RECHTSPERSOON_VENNOOTSCHAP("overige buitenlandse rechtspersoon vennootschap","overige_buitenlandse_rechtspersoon_vennootschap"),
+    PUBLIEKRECHTELIJKE_RECHTSPERSOON("publiekrechtelijke Rechtspersoon","publiekrechtelijke_rechtspersoon"),
+    REDERIJ("rederij","rederij"),
+    STICHTING("stichting","stichting"),
+    VENNOOTSCHAP_ONDER_FIRMA("vennootschap onder Firma","vennootschap_onder_firma"),
+    VERENINGING("vereniging","vereniging"),
+    VERENIGING_VAN_EIGENAARS("vereniging van Eigenaars","vereniging_van_eigenaars");
+
+    private final String zdsInnRechtsvorm;
+    private final String zgwInnRechtsvorm;
+
+    SoortRechtsvorm(String zdsInnRechtsvorm, String zgwInnRechtsvorm) {
+        this.zgwInnRechtsvorm = zgwInnRechtsvorm;
+        this.zdsInnRechtsvorm = zdsInnRechtsvorm;
+    }
+
+    public static Optional<SoortRechtsvorm> getSoortRechtsvorm(String innRechtsvorm){
+        return Arrays.stream(SoortRechtsvorm.values()).
+            filter(rechtsvorm -> innRechtsvorm!=null &&
+                (rechtsvorm.zdsInnRechtsvorm.toLowerCase().equals(innRechtsvorm.toLowerCase()) || rechtsvorm.zgwInnRechtsvorm.toLowerCase().equals(innRechtsvorm.toLowerCase()))
+            ).findFirst();
+    }
+}

--- a/src/main/java/nl/haarlem/translations/zdstozgw/translation/zds/services/ZaakService.java
+++ b/src/main/java/nl/haarlem/translations/zdstozgw/translation/zds/services/ZaakService.java
@@ -1,9 +1,9 @@
 /*
  * Copyright 2020-2021 The Open Zaakbrug Contributors
  *
- * Licensed under the EUPL, Version 1.2 or – as soon they will be approved by the 
+ * Licensed under the EUPL, Version 1.2 or – as soon they will be approved by the
  * European Commission - subsequent versions of the EUPL (the "Licence");
- * 
+ *
  * You may not use this work except in compliance with the Licence.
  * You may obtain a copy of the Licence at:
  *
@@ -145,7 +145,7 @@ public class ZaakService {
 		addRolToZgw(zgwZaak, zgwZaakType, zdsZaak.heeftAlsGemachtigde, zgwRolOmschrijving.getHeeftAlsGemachtigde());
 		addRolToZgw(zgwZaak, zgwZaakType, zdsZaak.heeftAlsOverigBetrokkene, zgwRolOmschrijving.getHeeftAlsOverigBetrokkene());
 
-		
+
 		/*
             <object StUF:sleutelVerzendend="184105" StUF:entiteittype="ZAK">
                <identificatie>1900207494</identificatie>
@@ -177,8 +177,8 @@ public class ZaakService {
                </heeftBetrekkingOpAndere>
 				....
               </object>
-            
-            
+
+
             <object StUF:sleutelVerzendend="215427" StUF:entiteittype="ZAK">
                <identificatie>1900242904</identificatie>
 				....
@@ -196,14 +196,14 @@ public class ZaakService {
                   </gerelateerde>
                </heeftBetrekkingOpAndere>
                ....
-			   
+
             </object>
-            
-            
-		 */		
+
+
+		 */
 		// hoofd-zaak
 		if(zdsZaak.heeftAlsHoofdzaak != null) {
-			debugWarning("In zaak:" + zdsZaak.identificatie + " unsupported 'heeftAlsHoofdzaak'");			
+			debugWarning("In zaak:" + zdsZaak.identificatie + " unsupported 'heeftAlsHoofdzaak'");
 		}
 		// deel-zaak
 		if(zdsZaak.heeftAlsDeelzaak != null) {
@@ -222,18 +222,18 @@ public class ZaakService {
 						//	bijdrage	een zaak van het ZAAKTYPE levert een bijdrage aan het bereiken van de uitkomst van een zaak van het andere ZAAKTYPE
 						//	onderwerp	een zaak van het ZAAKTYPE heeft betrekking op een zaak van het andere ZAAKTYPE of een zaak van het andere ZAAKTYPE is relevant voor of is onderwerp van een zaak van het ZAAKTYPE
 						// 	vervolg		een zaak van het ZAAKTYPE is een te plannen vervolg op een zaak van het andere ZAAKTYPE
-						
+
 						// we need to make the relation to both sides (to get the expected behaviour)
 						zgwClient.addRelevanteAndereZaakToZaak(zgwZaak, zgwAndereZaak, "onderwerp");
-						zgwClient.addRelevanteAndereZaakToZaak(zgwAndereZaak, zgwZaak, "onderwerp"); 
+						zgwClient.addRelevanteAndereZaakToZaak(zgwAndereZaak, zgwZaak, "onderwerp");
 					}
-				}	
+				}
 			}
 		}
-		
-		// last, the resultaat and status (lastly, since it things go wrong, it is often over here) 
-		setResultaatAndStatus(zdsZaak, zgwZaak, zgwZaakType);		
-		
+
+		// last, the resultaat and status (lastly, since it things go wrong, it is often over here)
+		setResultaatAndStatus(zdsZaak, zgwZaak, zgwZaakType);
+
 		return zgwZaak;
 	}
 
@@ -241,7 +241,7 @@ public class ZaakService {
 		var zdsWasZaak = getZaakDetailsByIdentificatie(zdsWordtZaak.getIdentificatie());
 		updateZaak(zdsWasZaak, zdsWordtZaak);
 	}
-	
+
 	public void updateZaak(ZdsZaak zdsWasZaak, ZdsZaak zdsWordtZaak) {
 		log.debug("updateZaak:" + zdsWordtZaak.identificatie);
 		ZgwZaak zgwZaak = this.zgwClient.getZaakByIdentificatie(zdsWordtZaak.identificatie);
@@ -289,7 +289,7 @@ public class ZaakService {
 				}
 				else if(updatedZaak.verlenging.duur == null || updatedZaak.verlenging.duur.length() == 0) {
 					updatedZaak.verlenging = null;
-				}									
+				}
 				else if(!(updatedZaak.verlenging.duur.startsWith("P") && updatedZaak.verlenging.duur.endsWith("D"))) {
 					updatedZaak.verlenging.duur = "P" + updatedZaak.verlenging.duur + "D";
 				}
@@ -304,7 +304,7 @@ public class ZaakService {
 			log.debug("Update of zaakid:" + zdsWasZaak.identificatie + " has # " + wasVsWordtRolChanges.size() + " rol changes:");
 
 //			for(ChangeDetector.Change change : wasVsWordtRolChanges.keySet()) {
-//				log.info("Rol field:" + change.getField().getName() + " changetype:" + change.getChangeType() + " currentvalue:" + change.getCurrentValue() + " newvalue:" + change.getNewValue());				
+//				log.info("Rol field:" + change.getField().getName() + " changetype:" + change.getChangeType() + " currentvalue:" + change.getCurrentValue() + " newvalue:" + change.getNewValue());
 //			}
 
 			changeDetector.filterChangesByType(wasVsWordtRolChanges, ChangeDetector.ChangeType.NEW)
@@ -381,22 +381,22 @@ public class ZaakService {
 		}
 		return zgwStatusDatumTijd;
 	}
-	
+
 	public boolean setResultaatAndStatus(ZdsZaak zdsZaak, ZgwZaak zgwZaak, ZgwZaakType zgwZaakType) {
 		var changed = false;
 		var beeindigd = false;
 
 		var newStatuses = new ArrayList<ZgwStatus>();
-		
+
 		// Check if zaak already has the endstatus set (updateZaak can happen after zaak is closed)
 		var statusTypes = this.zgwClient.getStatusTypesByZaakType(zgwZaakType);
 		var endStatusType = statusTypes.stream()
 				.filter(statusType -> "true".equals(statusType.getIsEindstatus()))
 				.findFirst();
-		
+
 		var presentStatuses = this.zgwClient.getStatussenByZaakUrl(zgwZaak.url);
 		beeindigd = presentStatuses!=null && presentStatuses.stream().anyMatch(s -> s.statustype.equals(endStatusType.get().url) ? true : false);
-		
+
 		if (zdsZaak.heeft != null) {
 			for (ZdsHeeft zdsHeeftIterator : zdsZaak.heeft) {
 				ZdsGerelateerde zdsStatus = zdsHeeftIterator.gerelateerde;
@@ -408,7 +408,7 @@ public class ZaakService {
 					zgwStatus.statustype = zgwStatusType.url;
 					zgwStatus.statustoelichting = zgwStatusType.omschrijving;
 					String zdsStatusDatum = zdsHeeftIterator.getDatumStatusGezet();
-					
+
 					if("true".equals(zgwStatusType.getIsEindstatus())) {
 						// Difference between ZDS --> ZGW the behaviour of ending a zaak has changed.
 						// (more info at: https://vng-realisatie.github.io/gemma-zaken/standaard/zaken/index#zrc-007 )
@@ -438,7 +438,7 @@ public class ZaakService {
 								if(!s.statustype.equals((zgwStatus.statustype))) {
 									throw new ConverterException("found status on exact same timestamp with an different type. Got statustype" + s.statustype + " found:" + zgwStatus.statustype);
 								}
-								// already exist	
+								// already exist
 								statusexists = true;
 							}
 						}
@@ -452,40 +452,40 @@ public class ZaakService {
 				}
 			}
 		}
-				
+
 		// if there is a resultaat
 		if (zdsZaak.resultaat != null && zdsZaak.resultaat.omschrijving != null && zdsZaak.resultaat.omschrijving.length() > 0) {
 			var resultaatomschrijving = zdsZaak.resultaat.omschrijving;
 			log.debug("Update of zaakid:" + zdsZaak.identificatie + " wants resultaat to be changed to:" + zdsZaak.resultaat.omschrijving );
 			var zgwResultaatType = this.zgwClient.getResultaatTypeByZaakTypeAndOmschrijving(zgwZaakType, zdsZaak.resultaat.omschrijving);
 			if(zgwResultaatType == null) {
-				throw new ConverterException("Resultaattype: " + resultaatomschrijving + " niet gevonden bij Zaaktype: " + zgwZaakType.identificatie);							
+				throw new ConverterException("Resultaattype: " + resultaatomschrijving + " niet gevonden bij Zaaktype: " + zgwZaakType.identificatie);
 			}
-			
+
 			// remove any existing resultaten (we only want to have 1)
 			var resultaten = this.zgwClient.getResultatenByZaakUrl(zgwZaak.url);
 			for (ZgwResultaat resultaat : resultaten) {
 				debugWarning("Zaak with identificatie:" + zdsZaak.identificatie + " already has resultaat #" + resultaten.indexOf(resultaat) + " met toelichting:" +  resultaat.toelichting + "(" + resultaat.uuid  + "), will be deleted");
 				this.zgwClient.deleteZaakResultaat(resultaat.uuid);
 			}
-			
+
 			ZgwResultaat zgwResultaat = new ZgwResultaat();
 			zgwResultaat.zaak = zgwZaak.url;
 			zgwResultaat.resultaattype = zgwResultaatType.url;
 			zgwResultaat.toelichting = zdsZaak.resultaat.omschrijving;
-			
+
 			this.zgwClient.addZaakResultaat(zgwResultaat);
-			changed = true;			
+			changed = true;
 		}
-		
+
 		// Use-case of the current action closing a zaak and no resultaat being present
 		Optional<ZgwStatus> newEndStatus = Optional.empty();
 		if(endStatusType.isPresent()) {
 			newEndStatus = newStatuses.stream()
 					.filter(newStatus -> newStatus.statustype.equals(endStatusType.get().url))
 					.findFirst();
-		}	
-		
+		}
+
 		if(newEndStatus.isPresent()) {
 			var resultaten = this.zgwClient.getResultatenByZaakUrl(zgwZaak.url);
 			if(resultaten.isEmpty()) {
@@ -493,14 +493,14 @@ public class ZaakService {
 					if(beeindig.zaakType.equals(zgwZaakType.getIdentificatie())) {
 						var zgwResultaatType = this.zgwClient.getResultaatTypeByZaakTypeAndOmschrijving(zgwZaakType, beeindig.coalesceResultaat);
 						if(zgwResultaatType == null) {
-							throw new ConverterException("Resultaattype: '" + beeindig.coalesceResultaat + "' niet gevonden bij Zaaktype:'" + zgwZaakType.identificatie + "'");							
+							throw new ConverterException("Resultaattype: '" + beeindig.coalesceResultaat + "' niet gevonden bij Zaaktype:'" + zgwZaakType.identificatie + "'");
 						}
 						ZgwResultaat zgwResultaat = new ZgwResultaat();
 						zgwResultaat.zaak = zgwZaak.url;
 						zgwResultaat.resultaattype = zgwResultaatType.url;
 						zgwResultaat.toelichting = zgwResultaatType.omschrijving;
 						debugWarning("BeeindigZaakWanneerEinddatum was defined for zaaktype:'" + zgwZaakType.identificatie + "', zaak is about to be closed but has no resultaat, zaak will get resultaat:'" + zgwResultaatType.getOmschrijving() + "'");
-						this.zgwClient.addZaakResultaat(zgwResultaat);						
+						this.zgwClient.addZaakResultaat(zgwResultaat);
 					}
 				}
 			}
@@ -515,17 +515,17 @@ public class ZaakService {
 					if(resultaten.size() == 0) {
 						var zgwResultaatType = this.zgwClient.getResultaatTypeByZaakTypeAndOmschrijving(zgwZaakType, beeindig.coalesceResultaat);
 						if(zgwResultaatType == null) {
-							throw new ConverterException("Resultaattype: '" + beeindig.coalesceResultaat + "' niet gevonden bij Zaaktype:'" + zgwZaakType.identificatie + "'");							
+							throw new ConverterException("Resultaattype: '" + beeindig.coalesceResultaat + "' niet gevonden bij Zaaktype:'" + zgwZaakType.identificatie + "'");
 						}
 						ZgwResultaat zgwResultaat = new ZgwResultaat();
 						zgwResultaat.zaak = zgwZaak.url;
 						zgwResultaat.resultaattype = zgwResultaatType.url;
 						zgwResultaat.toelichting = zgwResultaatType.omschrijving;
 						debugWarning("BeeindigZaakWanneerEinddatum was defined for zaaktype:'" + zgwZaakType.identificatie + "' and an einddatum was provided, no resultaat, zaak will get resultaat:'" + zgwResultaatType.getOmschrijving() + "'");
-						this.zgwClient.addZaakResultaat(zgwResultaat);						
+						this.zgwClient.addZaakResultaat(zgwResultaat);
 					}
-								
-					var zgwStatusType = this.zgwClient.getLastStatusTypeByZaakType(zgwZaakType);					
+
+					var zgwStatusType = this.zgwClient.getLastStatusTypeByZaakType(zgwZaakType);
 					ZgwStatus zgwStatus = new ZgwStatus();
 					zgwStatus.zaak = zgwZaak.url;
 					zgwStatus.statustype = zgwStatusType.url;
@@ -538,12 +538,12 @@ public class ZaakService {
 				}
 			}
 		}
-		
+
 		newStatuses.forEach(newStatus -> this.zgwClient.addZaakStatus(newStatus));
 		if(!newStatuses.isEmpty()) {
 			changed = true;
 		}
-		
+
 		return changed;
 	}
 
@@ -561,7 +561,7 @@ public class ZaakService {
 		zgwRol.roltoelichting = typeRolOmschrijving + ": ";
 		if (zdsRol.gerelateerde.medewerker != null) {
 			zgwRol.betrokkeneIdentificatie = this.modelMapper.map(zdsRol.gerelateerde.medewerker, ZgwBetrokkeneIdentificatie.class);
-			zgwRol.roltoelichting += zdsRol.gerelateerde.medewerker.achternaam != null ? zdsRol.gerelateerde.medewerker.achternaam : zdsRol.gerelateerde.medewerker.identificatie; 
+			zgwRol.roltoelichting += zdsRol.gerelateerde.medewerker.achternaam != null ? zdsRol.gerelateerde.medewerker.achternaam : zdsRol.gerelateerde.medewerker.identificatie;
 			zgwRol.betrokkeneType = BetrokkeneType.MEDEWERKER.getDescription();
 		}
 		if (zdsRol.gerelateerde.natuurlijkPersoon != null) {
@@ -592,7 +592,7 @@ public class ZaakService {
 									openbareRuimteNaam = zdsRol.gerelateerde.natuurlijkPersoon.verblijfsadres.openbareRuimteNaam;
 								}
 							}
-						}			
+						}
 
 						zgwRol.betrokkeneIdentificatie.verblijfsadres = new ZgwAdres();
 						zgwRol.betrokkeneIdentificatie.verblijfsadres.aoaIdentificatie = zdsRol.gerelateerde.natuurlijkPersoon.verblijfsadres.identificatie;
@@ -620,52 +620,6 @@ public class ZaakService {
 			//zgwRol.betrokkeneIdentificatie.annIdentificatie = zdsRol.gerelateerde.nietNatuurlijkPersoon.annIdentificatie;
 			zgwRol.betrokkeneIdentificatie.statutaireNaam = zdsRol.gerelateerde.nietNatuurlijkPersoon.statutaireNaam;
 
-			var rechtsvorm = zdsRol.gerelateerde.nietNatuurlijkPersoon.innRechtsvorm.toLowerCase();
-			if(rechtsvorm == null || rechtsvorm.length() == 0 ) {
-				// do nothing
-			} else if(rechtsvorm.contains("vennootschap")) {
-				zgwRol.betrokkeneIdentificatie.innRechtsvorm = "besloten_vennootschap";
-			} else if(rechtsvorm.contains("economische")) {
-				zgwRol.betrokkeneIdentificatie.innRechtsvorm = "cooperatie_europees_economische_samenwerking";
-			} else if(rechtsvorm.contains("cooperatieve")) {
-				zgwRol.betrokkeneIdentificatie.innRechtsvorm = "europese_cooperatieve_venootschap";
-			} else if(rechtsvorm.contains("europese")) {
-				zgwRol.betrokkeneIdentificatie.innRechtsvorm = "europese_naamloze_vennootschap";
-			} else if(rechtsvorm.contains("kerkelijke")) {
-				zgwRol.betrokkeneIdentificatie.innRechtsvorm = "kerkelijke_organisatie";
-			} else if(rechtsvorm.contains("vennootschap")) {
-				zgwRol.betrokkeneIdentificatie.innRechtsvorm = "naamloze_vennootschap";
-			} else if(rechtsvorm.contains("waarborg")) {
-				zgwRol.betrokkeneIdentificatie.innRechtsvorm = "onderlinge_waarborg_maatschappij";
-			} else if(rechtsvorm.contains("privaatrechtelijke")) {
-				zgwRol.betrokkeneIdentificatie.innRechtsvorm = "overig_privaatrechtelijke_rechtspersoon";
-			} else if(rechtsvorm.contains("stichting")) {
-				zgwRol.betrokkeneIdentificatie.innRechtsvorm = "stichting";
-			} else if(rechtsvorm.contains("vereniging")) {
-				zgwRol.betrokkeneIdentificatie.innRechtsvorm = "vereniging";
-			} else if(rechtsvorm.contains("eigenaars")) {
-				zgwRol.betrokkeneIdentificatie.innRechtsvorm = "vereniging_van_eigenaars";
-			} else if(rechtsvorm.contains("publiekrechtelijke")) {
-				zgwRol.betrokkeneIdentificatie.innRechtsvorm = "publiekrechtelijke_rechtspersoon";
-			} else if(rechtsvorm.contains("firma")) {
-				zgwRol.betrokkeneIdentificatie.innRechtsvorm = "vennootschap_onder_firma";
-			} else if(rechtsvorm.contains("maatschap")) {
-				zgwRol.betrokkeneIdentificatie.innRechtsvorm = "maatschap";
-			} else if(rechtsvorm.contains("rederij")) {
-				zgwRol.betrokkeneIdentificatie.innRechtsvorm = "rederij";
-			} else if(rechtsvorm.contains("commanditaire")) {
-				zgwRol.betrokkeneIdentificatie.innRechtsvorm = "commanditaire_vennootschap";
-			} else if(rechtsvorm.contains("binnen")) {
-				zgwRol.betrokkeneIdentificatie.innRechtsvorm = "kapitaalvennootschap_binnen_eer";
-			} else if(rechtsvorm.contains("buitenlandse")) {
-				zgwRol.betrokkeneIdentificatie.innRechtsvorm = "overige_buitenlandse_rechtspersoon_vennootschap";
-			} else if(rechtsvorm.contains("buiten")) {
-				zgwRol.betrokkeneIdentificatie.innRechtsvorm = "kapitaalvennootschap_buiten_eer";
-			} else {
-				// maybe a good default?
-				debugWarning("Rechtsvorm:" + zdsRol.gerelateerde.nietNatuurlijkPersoon.innRechtsvorm + " kon niet worden geconverteerd, using default value: overig_privaatrechtelijke_rechtspersoon");
-				zgwRol.betrokkeneIdentificatie.innRechtsvorm = "overig_privaatrechtelijke_rechtspersoon";
-			}
 			//zgwRol.betrokkeneIdentificatie.bezoekadres;
 			zgwRol.roltoelichting  += zdsRol.gerelateerde.nietNatuurlijkPersoon.statutaireNaam;
 			zgwRol.betrokkeneType = BetrokkeneType.NIET_NATUURLIJK_PERSOON.getDescription();
@@ -709,17 +663,17 @@ public class ZaakService {
 		var relevanteDocumenten = new ArrayList<ZdsHeeftRelevant>();
 		var zgwZaakInformatieObjecten = this.zgwClient.getZaakInformatieObjectenByZaak(zgwZaak.url);
 		if(this.zgwClient.additionalCallToRetrieveRelatedObjectInformatieObjectenForCaching && zgwZaakInformatieObjecten.size() > 0) {
-			// fill the cache in the drc if needed 
+			// fill the cache in the drc if needed
 			var zgwObjectInformatieObjecten = this.zgwClient.getObjectInformatieObjectByObject(zgwZaak.url);
 			debugWarning("Retrieved ObjectInformatieObjecten to fill the cache on the (CMIS-)DRC (call not needed for ZdsToZgw)");
-		}	
+		}
 		for (ZgwZaakInformatieObject zgwZaakInformatieObject : zgwZaakInformatieObjecten) {
 			ZgwEnkelvoudigInformatieObject zgwEnkelvoudigInformatieObject = this.zgwClient
 					.getZaakDocumentByUrl(zgwZaakInformatieObject.informatieobject);
 			if (zgwEnkelvoudigInformatieObject == null || zgwEnkelvoudigInformatieObject.informatieobjecttype == null) {
 				throw new ConverterException("could not get the zaakdocument: "
 						+ zgwZaakInformatieObject.informatieobject + " for zaak:" + zaakidentificatie);
-			}			
+			}
 			ZgwInformatieObjectType documenttype = this.zgwClient
 					.getZgwInformatieObjectTypeByUrl(zgwEnkelvoudigInformatieObject.informatieobjecttype);
 			if (documenttype == null) {
@@ -785,12 +739,12 @@ public class ZaakService {
 		zgwEnkelvoudigInformatieObject.indicatieGebruiksrecht = "false";
 
 		if(zgwEnkelvoudigInformatieObject.status != null) {
-			/*			
+			/*
 			in_bewerking - (In bewerking) Aan het informatieobject wordt nog gewerkt.
 			ter_vaststelling - (Ter vaststelling) Informatieobject gereed maar moet nog vastgesteld worden.
 			definitief - (Definitief) Informatieobject door bevoegd iets of iemand vastgesteld dan wel ontvangen.
 			gearchiveerd - (Gearchiveerd) Informatieobject duurzaam bewaarbaar gemaakt; een gearchiveerd informatie-element.
-			*/			
+			*/
 			zgwEnkelvoudigInformatieObject.status = zgwEnkelvoudigInformatieObject.status.replace(" ", "_");
 			zgwEnkelvoudigInformatieObject.status = zgwEnkelvoudigInformatieObject.status.toLowerCase();
 			if(!List.of("in_bewerking", "ter_vaststelling", "definitief", "gearchiveerd").contains(zgwEnkelvoudigInformatieObject.status)) {
@@ -888,7 +842,7 @@ public class ZaakService {
 		if(result.vertrouwelijkAanduiding.length()==0) {
 			result.vertrouwelijkAanduiding=null;
 		}
-		
+
 
 		result.formaat = zgwEnkelvoudigInformatieObject.bestandsnaam
 				.substring(zgwEnkelvoudigInformatieObject.bestandsnaam.lastIndexOf(".") + 1);
@@ -1005,11 +959,11 @@ public class ZaakService {
 		zaak.verlenging = zgwZaak.getVerlenging() != null
 				? this.modelMapper.map(zgwZaak.getVerlenging(), ZdsVerlenging.class)
 				: null;
-		
+
 		if(zaak.verlenging != null && zaak.verlenging.duur != null) {
 			zaak.verlenging.duur = zaak.verlenging.duur.replace("P", "").replace("Y", "").replace("M", "").replace("D", "");
 		}
-		
+
 		// heefd deze zaak ook een hoofdzaak
 		var hoofdzaak = zgwZaak.getHoofdzaak();
 		if(hoofdzaak != null) {
@@ -1018,42 +972,42 @@ public class ZaakService {
 			zaak.heeftAlsHoofdzaak.entiteittype = "ZAKZAKBTR";
 			zaak.heeftAlsHoofdzaak.gerelateerde = new ZdsGerelateerde();
 			zaak.heeftAlsHoofdzaak.gerelateerde.entiteittype = "ZAK";
-			zaak.heeftAlsHoofdzaak.gerelateerde.identificatie = parentzaak.identificatie;		
+			zaak.heeftAlsHoofdzaak.gerelateerde.identificatie = parentzaak.identificatie;
 			zaak.heeftAlsHoofdzaak.gerelateerde.omschrijving = parentzaak.omschrijving;
-		}		
-		
+		}
+
 		// heeft deze zaak ook deelzaken
 		var deelzaken = zgwZaak.getDeelzaken();
 		for(String deelzaak: deelzaken) {
 			if(zaak.heeftAlsDeelzaak == null) {
 				zaak.heeftAlsDeelzaak = new ArrayList<ZdsHeeftGerelateerde>();
-			}			
-			var childzaak = zgwClient.getZaakByUrl(deelzaak);			
+			}
+			var childzaak = zgwClient.getZaakByUrl(deelzaak);
 			var heeftGerelateerde = new ZdsHeeftGerelateerde();
 			heeftGerelateerde.entiteittype = "ZAKZAKBTR";
 			heeftGerelateerde.gerelateerde = new ZdsGerelateerde();
 			heeftGerelateerde.gerelateerde.entiteittype = "ZAK";
-			heeftGerelateerde.gerelateerde.identificatie = childzaak.identificatie;			
+			heeftGerelateerde.gerelateerde.identificatie = childzaak.identificatie;
 			heeftGerelateerde.gerelateerde.omschrijving = childzaak.omschrijving;
 			zaak.heeftAlsDeelzaak.add(heeftGerelateerde);
 		}
-		
+
 		// heeft deze zaak ook gerelateerde zaken
 		var relevanteAndereZaken = zgwZaak.getRelevanteAndereZaken();
 		for(ZgwAndereZaak relevanteAndereZaak: relevanteAndereZaken) {
 			if(zaak.heeftBetrekkingOpAndere == null) {
 				zaak.heeftBetrekkingOpAndere = new ArrayList<ZdsHeeftGerelateerde>();
-			}			
-			var childzaak = zgwClient.getZaakByUrl(relevanteAndereZaak.url);			
+			}
+			var childzaak = zgwClient.getZaakByUrl(relevanteAndereZaak.url);
 			var heeftGerelateerde = new ZdsHeeftGerelateerde();
 			heeftGerelateerde.entiteittype = "ZAKZAKBTR";
 			heeftGerelateerde.gerelateerde = new ZdsGerelateerde();
 			heeftGerelateerde.gerelateerde.entiteittype = "ZAK";
-			heeftGerelateerde.gerelateerde.identificatie = childzaak.identificatie;		
+			heeftGerelateerde.gerelateerde.identificatie = childzaak.identificatie;
 			heeftGerelateerde.gerelateerde.omschrijving = childzaak.omschrijving;
 			zaak.heeftBetrekkingOpAndere.add(heeftGerelateerde);
-		}		
-		
+		}
+
 		var zdsStatussen = new ArrayList<ZdsHeeft>();
 		for (ZgwStatus zgwStatus : this.zgwClient.getStatussenByZaakUrl(zgwZaak.url)) {
 			ZgwStatusType zgwStatusType = this.zgwClient.getResource(zgwStatus.statustype, ZgwStatusType.class);
@@ -1194,7 +1148,7 @@ public class ZaakService {
 			throw new ConverterException("ZgwEnkelvoudigInformatieObjectByIdentiticatie with identificatie: " + zdsWasInformatieObject.identificatie + " has status 'defintief ' and cannot be locked and then changed");
 		}
 
-		
+
 		// https://github.com/Sudwest-Fryslan/OpenZaakBrug/issues/54
 		// 		Move code to the ModelMapperConfig.java
 		//		Also merge, we shouldnt overwrite the old values this hard
@@ -1228,27 +1182,27 @@ public class ZaakService {
 		}
 		zgwWordtEnkelvoudigInformatieObject.indicatieGebruiksrecht = "false";
 		if(zgwWordtEnkelvoudigInformatieObject.status != null) {
-			/*			
+			/*
 			in_bewerking - (In bewerking) Aan het informatieobject wordt nog gewerkt.
 			ter_vaststelling - (Ter vaststelling) Informatieobject gereed maar moet nog vastgesteld worden.
 			definitief - (Definitief) Informatieobject door bevoegd iets of iemand vastgesteld dan wel ontvangen.
 			gearchiveerd - (Gearchiveerd) Informatieobject duurzaam bewaarbaar gemaakt; een gearchiveerd informatie-element.
-			*/			
+			*/
 			zgwWordtEnkelvoudigInformatieObject.status = zgwWordtEnkelvoudigInformatieObject.status.replace(" ", "_");
 			zgwWordtEnkelvoudigInformatieObject.status = zgwWordtEnkelvoudigInformatieObject.status.toLowerCase();
 			if(!List.of("in_bewerking", "ter_vaststelling", "definitief", "gearchiveerd").contains(zgwWordtEnkelvoudigInformatieObject.status)) {
 				debugWarning("document-status: '" + zgwWordtEnkelvoudigInformatieObject.status + "', resetting to null (possible values: in_bewerking / ter_vaststelling / definitief / gearchiveerd)");
 				zgwWordtEnkelvoudigInformatieObject.status = null;
 			}
-		}		
-		
+		}
+
 		zgwWordtEnkelvoudigInformatieObject.lock = lock;
 		zgwWordtEnkelvoudigInformatieObject.url = zgwWasEnkelvoudigInformatieObject.url;
 		zgwWasEnkelvoudigInformatieObject = this.zgwClient.putZaakDocument(zgwWordtEnkelvoudigInformatieObject);
 		//ZgwZaak zgwZaak = this.zgwClient.getZaakByIdentificatie(zdsInformatieObject.isRelevantVoor.gerelateerde.identificatie);
 		//ZgwZaakInformatieObject zgwZaakInformatieObject = addZaakInformatieObject(zgwEnkelvoudigInformatieObject, zgwZaak.url);
-		
-		
+
+
 		ZgwLock zgwLock = new ZgwLock();
 		zgwLock.lock = lock;
 		this.zgwClient.getZgwInformatieObjectUnLock(zgwWordtEnkelvoudigInformatieObject, zgwLock);


### PR DESCRIPTION
Moved conversion of soortRechtsvorm from ZaakService to ModelMapperConfig  innRechtsvorm will be set to null if the provided StUF value cannot be converted. This used to set an incorrect default value of 'overig_privaatrechtelijke_rechtspersoon'